### PR TITLE
feat: add releaseCache option to force cache release

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,14 +27,20 @@ You can configure the resource with the following options :
 ^.^|string
 ^.^|my-redis-cache
 
+.^|releaseCache
+^.^|X
+| Release the cache when API is stopped? If enabled, the resource will release the cache. If not, you will have to manage it by yourself on your Redis server.
+^.^|boolean
+^.^|false
+
 .^|maxTotal
 ^.^|X
 |The maximum number of connections that are supported by the pool.
 ^.^|integer
-^.^|256
+^.^|8
 
 .^|password
-^.^|X
+^.^|
 |The password of the instance.
 ^.^|string
 ^.^|
@@ -59,7 +65,7 @@ You can configure the resource with the following options :
 
 .^|useSsl
 ^.^|X
-| U+se SSL connections.
+| Use SSL connections.
 ^.^|boolean
 ^.^|true
 
@@ -99,7 +105,8 @@ You can configure the resource with the following options :
     "enabled" : true,
     "configuration" : {
         "name" : "my-redis-cache",
-        "maxTotal" : 256,
+        "releaseCache": false,
+        "maxTotal" : 8,
         "password" : "secret",
         "timeToLiveSeconds" : 600,
         "timeout" : 2000,
@@ -122,10 +129,10 @@ You can configure the resource with the following options :
 ^.^|X
 |The sentinel master id
 ^.^|string
-^.^|redis-master
+^.^|sentinel-master
 
 .^|password
-^.^|X
+^.^|-
 |The sentinel password.
 ^.^|string
 ^.^|
@@ -147,14 +154,15 @@ You can configure the resource with the following options :
     "enabled" : true,
     "configuration" : {
         "name" : "my-redis-cache",
-        "maxTotal" : 256,
+        "releaseCache": false,
+        "maxTotal" : 8,
         "password" : "secret",
         "timeToLiveSeconds" : 600,
         "timeout" : 2000,
         "useSsl" : true,
         "sentinelMode" : true,
         "sentinel" : {
-            "masterId" : "redis-master",
+            "masterId" : "sentinel-master",
             "password" : "secret",
             "nodes": [
               {

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,8 @@
 = Redis Cache Resource
 
 ifdef::env-github[]
-image:https://ci.gravitee.io/buildStatus/icon?job=gravitee-io/gravitee-resource-cache-redis/master["Build status", link="https://ci.gravitee.io/job/gravitee-io/job/gravitee-resource-cache-redis/"]
+image:https://img.shields.io/badge/License-Apache%202.0-blue.svg["License", link="https://github.com/gravitee-io/gravitee-resource-cache-redis/blob/master/LICENSE"]
+image:https://circleci.com/gh/gravitee-io/gravitee-resource-cache-redis.svg?style=svg["CircleCI", link="https://circleci.com/gh/gravitee-io/gravitee-resource-cache-redis"]
 image:https://badges.gitter.im/Join Chat.svg["Gitter", link="https://gitter.im/gravitee-io/gravitee-io?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"]
 endif::[]
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <commons-pool2.version>2.9.0</commons-pool2.version>
         <gravitee-gateway-api.version>1.26.0-SNAPSHOT</gravitee-gateway-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
-        <gravitee-resource-cache-provider-api.version>1.0.0</gravitee-resource-cache-provider-api.version>
+        <gravitee-resource-cache-provider-api.version>1.1.0-SNAPSHOT</gravitee-resource-cache-provider-api.version>
         <lettuce.version>5.3.4.RELEASE</lettuce.version>
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <spring-data-redis.version>2.3.4.RELEASE</spring-data-redis.version>

--- a/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
@@ -42,40 +42,21 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class RedisCacheResource extends CacheResource<RedisCacheResourceConfiguration> {
 
     private final Logger logger = LoggerFactory.getLogger(RedisCacheResource.class);
-    private static final char KEY_SEPARATOR = '_';
-    private static final String MAP_PREFIX = "cache-resources" + KEY_SEPARATOR;
+    private final StringRedisSerializer stringSerializer = new StringRedisSerializer();
     private RedisCacheManager redisCacheManager;
-
-    /**
-     * Generate a unique identifier for the resource cache.
-     *
-     * @param executionContext
-     * @return
-     */
-    private String computeConfigName(ExecutionContext executionContext) {
-        StringBuilder sb = new StringBuilder(MAP_PREFIX).append(configuration().getName());
-        Object apiId = executionContext.getAttribute(ExecutionContext.ATTR_API);
-        if (apiId != null) {
-            sb.append(KEY_SEPARATOR).append(apiId);
-        }
-        Object deployedAt = executionContext.getAttribute(ExecutionContext.ATTR_API_DEPLOYED_AT);
-        if (deployedAt != null) {
-            sb.append(KEY_SEPARATOR).append(deployedAt);
-        }
-        return sb.toString();
-    }
 
     @Override
     protected void doStart() throws Exception {
         super.doStart();
         logger.debug("Create redis cache manager");
-        StringRedisSerializer stringSerializer = new StringRedisSerializer();
+
         try {
             RedisCacheConfiguration conf = RedisCacheConfiguration
                 .defaultCacheConfig()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(stringSerializer))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(stringSerializer))
                 .entryTtl(Duration.ofSeconds(configuration().getTimeToLiveSeconds()));
+
             this.redisCacheManager = RedisCacheManager.builder(getConnectionFactory()).cacheDefaults(conf).build();
         } catch (Throwable e) {
             logger.error("Cannot create redis cache manager", e);
@@ -83,8 +64,19 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
     }
 
     @Override
+    public String keySeparator() {
+        return ":";
+    }
+
+    @Override
     public Cache getCache(ExecutionContext executionContext) {
-        return new RedisDelegate(this.redisCacheManager.getCache(computeConfigName(executionContext)));
+        return new RedisDelegate(
+            this.redisCacheManager.getCache("gravitee:"),
+            executionContext,
+            stringSerializer,
+            (int) configuration().getTimeToLiveSeconds(),
+            configuration().isReleaseCache()
+        );
     }
 
     private LettucePoolingClientConfiguration buildLettuceClientConfiguration() {

--- a/src/main/java/io/gravitee/resource/cache/redis/configuration/RedisCacheResourceConfiguration.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/configuration/RedisCacheResourceConfiguration.java
@@ -23,11 +23,12 @@ import io.gravitee.resource.api.ResourceConfiguration;
  */
 public class RedisCacheResourceConfiguration implements ResourceConfiguration {
 
-    private String name = "redis";
-    private int maxTotal = 256;
+    private String name = "my-redis-cache";
+    private int maxTotal = 8;
     private String password;
     private long timeToLiveSeconds = 0;
     private long timeout = 2000;
+    private boolean releaseCache = false;
     private boolean useSsl = true;
     private boolean sentinelMode = false;
     private HostAndPort standalone = new HostAndPort();
@@ -71,6 +72,14 @@ public class RedisCacheResourceConfiguration implements ResourceConfiguration {
 
     public void setTimeout(long timeout) {
         this.timeout = timeout;
+    }
+
+    public boolean isReleaseCache() {
+        return releaseCache;
+    }
+
+    public void setReleaseCache(boolean releaseCache) {
+        this.releaseCache = releaseCache;
     }
 
     public boolean isUseSsl() {

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -8,11 +8,17 @@
       "type" : "string",
       "default": "my-redis-cache"
     },
+    "releaseCache": {
+      "title": "Release the cache when API is stopped?",
+      "description": "If enabled, the resource will release the cache. If not, you will have to manage it by yourself on your Redis server.",
+      "type": "boolean",
+      "default": false
+    },
     "maxTotal" : {
       "title": "Max total",
       "description": "The maximum number of connections that are supported by the pool.",
       "type" : "integer",
-      "default": "256"
+      "default": "8"
     },
     "password": {
       "title": "Password",
@@ -79,7 +85,7 @@
           "title": "Master",
           "description": "The sentinel master id",
           "type": "String",
-          "default": "redis-master"
+          "default": "sentinel-master"
         },
         "password": {
           "title": "Sentinel password",
@@ -114,7 +120,6 @@
       },
       "required": [
         "masterId",
-        "password",
         "nodes"
       ],
       "x-schema-form": {
@@ -123,7 +128,6 @@
     }
   },
   "required": [
-    "name",
-    "password"
+    "name"
   ]
 }


### PR DESCRIPTION
gravitee-io/issues#5712

I use `:` as KEY_SEPARATOR for build the cache key. It was important for store the value in a Redis folder. (see: screenshot)

![Capture d’écran 2021-06-25 à 16 25 52](https://user-images.githubusercontent.com/1457497/123439962-91268000-d5d2-11eb-92e0-3aa3d764f2f2.png)

The data structure in Redis is : 
 - gv:  (default gravitee prefix)
   - $resource-name 
     -  $api-id
       => value to store 

If releaseCache option is enable, I add the deployment timestamp to store the value:
 - gv:  (default gravitee prefix)
   - $resource-name 
     -  $api-id
         - $deployed-at
         => value to store 