### PR TITLE
cache_redis-package-bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,101 +34,6 @@ orbs:
   gravitee: gravitee-io/gravitee@1.0
   secrethub: secrethub/cli@1.1.0
 
-jobs:
-
-  package_bundle:
-    docker:
-      - image: 'cimg/node:16.3.0'
-    environment:
-      SECRETS_FOLDER: '/tmp/gravit33bot/.secrets'
-    
-
-
-    steps:
-      #- checkout
-      # /tmp/package-bundle-resources/*.zip persisted to workspace by  [standalone release]
-      # also secrets
-      # also /tmp/gio.maven.project.release.version
-
-      - run:
-          name: "test"
-          command: |
-                    pwd 
-                    ls -alh
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: "Check release_version_file_helper retrieved from Pipeline workspace"
-          command: |
-                    ls -alh /tmp/gio.maven.project.release.version
-                    export GIO_RELEASE_VERSION=$(cat /tmp/gio.maven.project.release.version)
-                    echo "GIO_RELEASE_VERSION=[${GIO_RELEASE_VERSION}]"
-                    echo "export GIO_RELEASE_VERSION=${GIO_RELEASE_VERSION}" >> $BASH_ENV
-      - run:
-          name: "Check GIO_RELEASE_VERSION is well defined in Pipeline BASH_ENV"
-          command: |
-                    echo "GIO_RELEASE_VERSION=[${GIO_RELEASE_VERSION}]"
-                    if [ "x${GIO_RELEASE_VERSION}" == "x" ]; then
-                      echo "GIO_RELEASE_VERSION env.var is not set, but is expected to be"
-                      exit 3
-                    fi;
-      - run:
-          name: "Check bundled *.zip persisted to Pipeline workspace"
-          command: |
-                    echo "# ---------------------------------------------------------------------- #"
-                    echo "# - Check gravitee-policy-http-signature bundled *.zip persisted to Pipeline workspace"
-                    echo "# ---------------------------------------------------------------------- #"
-                    ls -allh /tmp/package-bundle-resources/
-                    ls -allh /tmp/package-bundle-resources/*.zip
-                    echo "# ---------------------------------------------------------------------- #"
-                    find /tmp/package-bundle-resources -wholename '/tmp/package-bundle-resources/*.zip'
-      - run:
-          name: "Check secrets retrieved from Pipeline workspace"
-          command: |
-                    echo "# ---------------------------------------------------------------------- #"
-                    echo "# - # Check secrets retrieved from Pipeline workspace"
-                    echo "# ---------------------------------------------------------------------- #"
-                    ls -allh ${SECRETS_FOLDER}/dry.release.settings.xml
-                    ls -allh ${SECRETS_FOLDER}/non.dry.release.settings.xml
-                    ls -allh ${SECRETS_FOLDER}/nexus.staging.settings.xml
-                    ls -allh ${SECRETS_FOLDER}/.s3cmd/aws_access_key
-                    ls -allh ${SECRETS_FOLDER}/.s3cmd/aws_secret_key
-                    ls -allh ${SECRETS_FOLDER}/.gungpg/graviteebot.gpg.pub.key
-                    ls -allh ${SECRETS_FOLDER}/.gungpg/graviteebot.gpg.priv.key
-                    ls -allh ${SECRETS_FOLDER}/git_user_name
-                    ls -allh ${SECRETS_FOLDER}/git_user_email
-                    ls -allh ${SECRETS_FOLDER}/dockerhub/user_name
-                    ls -allh ${SECRETS_FOLDER}/dockerhub/user_token
-                    echo "# ---------------------------------------------------------------------- #"
-                    ls -allh ${SECRETS_FOLDER}/git_ssh_pub_key
-                    ls -allh ${SECRETS_FOLDER}/git_ssh_private_key
-                    echo "# ---------------------------------------------------------------------- #"
-
-      - run:
-          name: "generate /tmp/gio.maven.project.release.version"
-          command: |
-                    echo "$GIO_RELEASE_VERSION"  >  /tmp/gio.maven.project.release.version
-
-      - setup_remote_docker
-          # ---
-      # Package Bundle must publish https://download.gravitee.io/#graviteeio-apim/plugins/resources/gravitee-resource-cache-redis/gravitee-resource-cache-redis-${GIO_RELEASE_VERSION}.zip
-      #
-      #
-      #   /tmp/package-bundle-resources/gravitee-resource-cache-redis-${GIO_RELEASE_VERSION}.zip  ===>> https://download.gravitee.io/#graviteeio-apim/plugins/resources/gravitee-resource-cache-redis/gravitee-resource-cache-redis-${GIO_RELEASE_VERSION}.zip
-      #
-      #
-      - gravitee/d_publish_package_bundle_unit:
-          #dry_run: << pipeline.parameters.dry_run >>
-          dry_run: false
-          zip_file_path:  /tmp/package-bundle-resources/gravitee-resource-cache-redis-GIO_VERSION_PLACEHOLDER.zip
-          # zip_file_path: /tmp/ae-main-zip-bundle-repackage/gravitee-policy-http-signature-GIO_VERSION_PLACEHOLDER.zip
-          publish_folder_path: graviteeio-apim/plugins/resources/gravitee-resource-cache-redis
-          publish_zip_filename: gravitee-resource-cache-redis-GIO_VERSION_PLACEHOLDER.zip
-          release_version_file_helper: /tmp/gio.maven.project.release.version
-          s3_bucket_name: "gravitee-releases-downloads"
-          placeholder: GIO_VERSION_PLACEHOLDER
-
-
 
 workflows:
   version: 2.1
@@ -259,9 +164,10 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
-      - package_bundle:
+      - gravitee/d_cache_redis_package_bundle:
           requires:
             - maven_n_git_release
+          dry_run: false
   standalone_release_dry_run:
     when:
       and:
@@ -282,9 +188,10 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
-      - package_bundle:
+      - gravitee/d_cache_redis_package_bundle:
           requires:
             - maven_n_git_release
+          dry_run: true
 
   standalone_nexus_staging:
     # ---
@@ -360,6 +267,10 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+      - gravitee/d_cache_redis_package_bundle:
+          requires:
+            - maven_n_git_release
+          dry_run: false
 
   standalone_release_replay_dry_run:
     when:
@@ -382,6 +293,10 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+      - gravitee/d_cache_redis_package_bundle:
+          requires:
+            - maven_n_git_release
+          dry_run: true
 
   standalone_nexus_staging_replay:
     # ---


### PR DESCRIPTION
here below the CircleCI Pipeline link : it launches the workflow "standalone_release_replay" in dry-run mode, the newly added/modified job in this pipeline is "d_cache_redis_package_bundle"  used in order to "upload the zip files generated by the artifactory in the gravitee.download" 

https://app.circleci.com/pipelines/github/gravitee-io/gravitee-resource-cache-redis/85/workflows/085424ea-b3a2-423b-839f-69f9313973e6

Link to the S3 bucket : https://gravitee-dry-releases-downloads.cellar-c2.services.clever-cloud.com/index.html#graviteeio-apim/plugins/resources/gravitee-resource-cache-redis/

Link to the slab documentation : https://gravitee.slab.com/posts/gravitee-resource-cache-redis-waqbc049