### PR TITLE
chore: rename 'jupiter' package in 'reactive'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_plugin-release-config:
@@ -32,4 +32,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/pom.xml
+++ b/pom.xml
@@ -37,9 +37,9 @@
     <properties>
         <gravitee-bom.version>2.1</gravitee-bom.version>
         <commons-pool2.version>2.9.0</commons-pool2.version>
-        <gravitee-gateway-api.version>1.44.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>2.1.0-alpha.18</gravitee-gateway-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
-        <gravitee-resource-cache-provider-api.version>1.3.0</gravitee-resource-cache-provider-api.version>
+        <gravitee-resource-cache-provider-api.version>1.4.0-alpha.1</gravitee-resource-cache-provider-api.version>
         <lettuce.version>5.3.4.RELEASE</lettuce.version>
         <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
         <spring-data-redis.version>2.3.4.RELEASE</spring-data-redis.version>

--- a/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
@@ -17,7 +17,7 @@ package io.gravitee.resource.cache.redis;
 
 import static java.lang.Boolean.TRUE;
 
-import io.gravitee.gateway.jupiter.api.context.GenericExecutionContext;
+import io.gravitee.gateway.reactive.api.context.GenericExecutionContext;
 import io.gravitee.resource.cache.api.Cache;
 import io.gravitee.resource.cache.api.CacheResource;
 import io.gravitee.resource.cache.redis.configuration.HostAndPort;


### PR DESCRIPTION
related to APIM-718
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.3.0-apim-718-rename-v4-terms-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache-redis/1.3.0-apim-718-rename-v4-terms-SNAPSHOT/gravitee-resource-cache-redis-1.3.0-apim-718-rename-v4-terms-SNAPSHOT.zip)
  <!-- Version placeholder end -->
