### PR TITLE
Use latest cache provider api

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.1
+    gravitee: gravitee-io/gravitee@4.8.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,9 @@
-**Issue**
+## Issue
 
-https://github.com/gravitee-io/issues/issues/XXXXX
+https://gravitee.atlassian.net/browse/XXXXX
 
-**Description**
+## Description
 
 A small description of what you did in that PR.
 
-**Additional context**
-
-<!-- Add any other context about the PR here -->
-<!-- It can be links to other PRs or docs or drawing -->
-<!-- Or reproduction steps in case of bug fix -->
+## Additional context

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,3 @@
 {
-  "extends": ["config:base", "schedule:earlyMondays"],
-  "prConcurrentLimit": 3,
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
-    }
-  ]
+    "extends": ["github>gravitee-io/renovate-config:policy"]
 }

--- a/README.adoc
+++ b/README.adoc
@@ -23,8 +23,9 @@ Current implementation of the cache resource is based on https://redis.io/[Redis
 |===
 | Plugin version | APIM version
 
-| 1.5.0            | 4.0 to 4.4
-| 2.0.0            | 4.5 to latest
+| 1.5            | 4.0 to 4.4
+| 2.0            | 4.5 to latest
+| 3.0            | 4.6 to latest
 |===
 
 == Configuration

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.0</version>
+        <version>22.2.2</version>
     </parent>
 
     <groupId>io.gravitee.resource</groupId>
@@ -35,16 +35,18 @@
     <description>The resource is used to maintain a cache and link it to the API lifecycle. Redis provides a different range of persistence options, it means that the cache can keep data after reboot.</description>
 
     <properties>
-        <gravitee-bom.version>4.0.0</gravitee-bom.version>
+        <gravitee-bom.version>8.1.16</gravitee-bom.version>
         <commons-pool2.version>2.9.0</commons-pool2.version>
         <gravitee-gateway-api.version>2.1.0</gravitee-gateway-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-resource-cache-provider-api.version>1.4.0</gravitee-resource-cache-provider-api.version>
         <lettuce.version>5.3.4.RELEASE</lettuce.version>
-        <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
         <spring-data-redis.version>2.3.4.RELEASE</spring-data-redis.version>
+
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/resources</publish-folder-path>
+
+        <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -184,23 +186,6 @@
                         <phase>package</phase>
                         <goals>
                             <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>com.hubspot.maven.plugins</groupId>
-                <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.17</version>
-                <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
-                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.resource</groupId>
     <artifactId>gravitee-resource-cache-redis</artifactId>
-    <version>2.0.0</version>
+    <version>3.0.0-APIM-7152-use-latest-cache-provider-api-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Resource - Cache - Redis</name>
     <description>The resource is used to maintain a cache and link it to the API lifecycle. Redis provides a different range of persistence options, it means that the cache can keep data after reboot.</description>
@@ -37,9 +37,9 @@
     <properties>
         <gravitee-bom.version>8.1.16</gravitee-bom.version>
         <commons-pool2.version>2.9.0</commons-pool2.version>
-        <gravitee-gateway-api.version>2.1.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>3.9.0-alpha.11</gravitee-gateway-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
-        <gravitee-resource-cache-provider-api.version>1.4.0</gravitee-resource-cache-provider-api.version>
+        <gravitee-resource-cache-provider-api.version>2.0.0</gravitee-resource-cache-provider-api.version>
         <lettuce.version>5.3.4.RELEASE</lettuce.version>
         <spring-data-redis.version>2.3.4.RELEASE</spring-data-redis.version>
 

--- a/src/assembly/resource-assembly.xml
+++ b/src/assembly/resource-assembly.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
@@ -18,6 +18,7 @@ package io.gravitee.resource.cache.redis;
 import static java.lang.Boolean.TRUE;
 
 import io.gravitee.gateway.reactive.api.context.GenericExecutionContext;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.resource.cache.api.Cache;
 import io.gravitee.resource.cache.api.CacheResource;
 import io.gravitee.resource.cache.redis.configuration.HostAndPort;
@@ -73,6 +74,11 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
 
     @Override
     public Cache getCache(GenericExecutionContext ctx) {
+        return getCache(ctx.getAttributes());
+    }
+
+    @Override
+    public Cache getCache(BaseExecutionContext ctx) {
         return getCache(ctx.getAttributes());
     }
 

--- a/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -92,7 +92,8 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
     }
 
     private LettucePoolingClientConfiguration buildLettuceClientConfiguration() {
-        final LettucePoolingClientConfiguration.LettucePoolingClientConfigurationBuilder builder = LettucePoolingClientConfiguration.builder();
+        final LettucePoolingClientConfiguration.LettucePoolingClientConfigurationBuilder builder =
+            LettucePoolingClientConfiguration.builder();
         builder.commandTimeout(Duration.ofMillis(configuration().getTimeout()));
         if (configuration().isUseSsl()) {
             builder.useSsl();

--- a/src/main/java/io/gravitee/resource/cache/redis/RedisDelegate.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/RedisDelegate.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/resource/cache/redis/configuration/HostAndPort.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/configuration/HostAndPort.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/resource/cache/redis/configuration/RedisCacheResourceConfiguration.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/configuration/RedisCacheResourceConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/resource/cache/redis/configuration/RedisSentinelConfiguration.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/configuration/RedisSentinelConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/resource/cache/redis/configuration/RedisStandaloneConfiguration.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/configuration/RedisStandaloneConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,162 +1,153 @@
 {
-  "type": "object",
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "properties": {
-    "releaseCache": {
-      "title": "Release the cache when API is stopped?",
-      "description": "If enabled, the resource will release the cache. If not, you will have to manage it by yourself on your Redis server.",
-      "type": "boolean",
-      "default": false
-    },
-    "maxTotal": {
-      "title": "Max total",
-      "description": "The maximum number of connections that are supported by the pool.",
-      "type": "integer",
-      "default": 8
-    },
-    "password": {
-      "title": "Password",
-      "description": "The password of the instance.",
-      "type": "string",
-      "writeOnly": true
-    },
-    "timeToLiveSeconds": {
-      "title": "Time to live (in seconds)",
-      "type": "integer",
-      "description": "The maximum number of seconds an element can exist in the cache regardless of use. The element expires at this limit and will no longer be returned from the cache. The default value is 0, which means no timeToLive (TTL) eviction takes place (infinite lifetime).",
-      "default": 0,
-      "minimum": 0
-    },
-    "timeout": {
-      "title": "Timeout (in milliseconds)",
-      "description": "The timeout parameter specifies the connection timeout and the read/write timeout.",
-      "type": "integer",
-      "default": 2000,
-      "minimum": 0
-    },
-    "useSsl": {
-      "title": "Use SSL",
-      "description": "Use SSL connections.",
-      "type": "boolean",
-      "default": true
-    },
-    "standalone": {
-      "type": "object",
-      "oneOf": [
-        {
-          "title": "Configure standalone",
-          "properties": {
-            "enabled": {
-              "const": true
-            },
-            "host": {
-              "title": "Host",
-              "description": "The host of the instance",
-              "type": "string",
-              "default": "localhost"
-            },
-            "port": {
-              "title": "Port",
-              "description": "The port of the instance",
-              "type": "integer",
-              "default": 6379
-            }
-          },
-          "required": [
-            "host",
-            "port"
-          ]
+    "type": "object",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+        "releaseCache": {
+            "title": "Release the cache when API is stopped?",
+            "description": "If enabled, the resource will release the cache. If not, you will have to manage it by yourself on your Redis server.",
+            "type": "boolean",
+            "default": false
         },
-        {
-          "title": "Standalone disabled",
-          "properties": {
-            "enabled": {
-              "const": false
-            }
-          }
-        }
-      ],
-      "default": {
-        "enabled": true
-      },
-      "gioConfig": {
-        "disableIf": {
-          "$eq": {
-            "value.sentinel.enabled": true
-          }
-        }
-      }
-    },
-    "sentinel": {
-      "type": "object",
-      "oneOf": [
-        {
-          "title": "Configure sentinel",
-          "properties": {
-            "enabled": {
-              "const": true
-            },
-            "masterId": {
-              "title": "Master",
-              "description": "The sentinel master id",
-              "type": "string",
-              "default": "sentinel-master"
-            },
-            "password": {
-              "title": "Sentinel password",
-              "description": "The sentinel password",
-              "type": "string",
-              "writeOnly": true
-            },
-            "nodes": {
-              "type": "array",
-              "title": "Sentinel nodes",
-              "items": {
-                "type": "object",
-                "title": "Node",
-                "properties": {
-                  "host": {
-                    "title": "The host of node",
-                    "type": "string",
-                    "default": "localhost"
-                  },
-                  "port": {
-                    "title": "The port of node",
-                    "type": "integer",
-                    "default": 26379
-                  }
-                },
-                "required": [
-                  "host",
-                  "port"
-                ]
-              },
-              "default": [
+        "maxTotal": {
+            "title": "Max total",
+            "description": "The maximum number of connections that are supported by the pool.",
+            "type": "integer",
+            "default": 8
+        },
+        "password": {
+            "title": "Password",
+            "description": "The password of the instance.",
+            "type": "string",
+            "writeOnly": true
+        },
+        "timeToLiveSeconds": {
+            "title": "Time to live (in seconds)",
+            "type": "integer",
+            "description": "The maximum number of seconds an element can exist in the cache regardless of use. The element expires at this limit and will no longer be returned from the cache. The default value is 0, which means no timeToLive (TTL) eviction takes place (infinite lifetime).",
+            "default": 0,
+            "minimum": 0
+        },
+        "timeout": {
+            "title": "Timeout (in milliseconds)",
+            "description": "The timeout parameter specifies the connection timeout and the read/write timeout.",
+            "type": "integer",
+            "default": 2000,
+            "minimum": 0
+        },
+        "useSsl": {
+            "title": "Use SSL",
+            "description": "Use SSL connections.",
+            "type": "boolean",
+            "default": true
+        },
+        "standalone": {
+            "type": "object",
+            "oneOf": [
                 {
-                  "host": "localhost",
-                  "port": 26379
+                    "title": "Configure standalone",
+                    "properties": {
+                        "enabled": {
+                            "const": true
+                        },
+                        "host": {
+                            "title": "Host",
+                            "description": "The host of the instance",
+                            "type": "string",
+                            "default": "localhost"
+                        },
+                        "port": {
+                            "title": "Port",
+                            "description": "The port of the instance",
+                            "type": "integer",
+                            "default": 6379
+                        }
+                    },
+                    "required": ["host", "port"]
+                },
+                {
+                    "title": "Standalone disabled",
+                    "properties": {
+                        "enabled": {
+                            "const": false
+                        }
+                    }
                 }
-              ]
+            ],
+            "default": {
+                "enabled": true
+            },
+            "gioConfig": {
+                "disableIf": {
+                    "$eq": {
+                        "value.sentinel.enabled": true
+                    }
+                }
             }
-          },
-          "required": [
-            "masterId",
-            "nodes"
-          ]
         },
-        {
-          "title": "Sentinel disabled",
-          "description": "Sentinel provides high availability for Redis. In practical terms this means that using Sentinel you can create a Redis deployment that resists without human intervention certain kinds of failures.",
-          "properties": {
-            "enabled": {
-              "const": false
+        "sentinel": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Configure sentinel",
+                    "properties": {
+                        "enabled": {
+                            "const": true
+                        },
+                        "masterId": {
+                            "title": "Master",
+                            "description": "The sentinel master id",
+                            "type": "string",
+                            "default": "sentinel-master"
+                        },
+                        "password": {
+                            "title": "Sentinel password",
+                            "description": "The sentinel password",
+                            "type": "string",
+                            "writeOnly": true
+                        },
+                        "nodes": {
+                            "type": "array",
+                            "title": "Sentinel nodes",
+                            "items": {
+                                "type": "object",
+                                "title": "Node",
+                                "properties": {
+                                    "host": {
+                                        "title": "The host of node",
+                                        "type": "string",
+                                        "default": "localhost"
+                                    },
+                                    "port": {
+                                        "title": "The port of node",
+                                        "type": "integer",
+                                        "default": 26379
+                                    }
+                                },
+                                "required": ["host", "port"]
+                            },
+                            "default": [
+                                {
+                                    "host": "localhost",
+                                    "port": 26379
+                                }
+                            ]
+                        }
+                    },
+                    "required": ["masterId", "nodes"]
+                },
+                {
+                    "title": "Sentinel disabled",
+                    "description": "Sentinel provides high availability for Redis. In practical terms this means that using Sentinel you can create a Redis deployment that resists without human intervention certain kinds of failures.",
+                    "properties": {
+                        "enabled": {
+                            "const": false
+                        }
+                    }
+                }
+            ],
+            "default": {
+                "enabled": false
             }
-          }
         }
-      ],
-      "default": {
-        "enabled": false
-      }
     }
-  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7152

## Description

Implements getCache for BaseExecutionContext

**BREAKING CHANGE**: requires gravitee-gateway-api 3.9.0+ & resource-cache-provider-api 2.0.0+
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-APIM-7152-use-latest-cache-provider-api-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache-redis/3.0.0-APIM-7152-use-latest-cache-provider-api-SNAPSHOT/gravitee-resource-cache-redis-3.0.0-APIM-7152-use-latest-cache-provider-api-SNAPSHOT.zip)
  <!-- Version placeholder end -->
