### PR TITLE
fix: udpate schema form for EL and secrets support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -49,7 +49,7 @@ You can configure the resource with the following options :
 | Release the cache when API is stopped? If enabled, the resource will release the cache. If not, you will have to manage it by yourself on your Redis server.
 ^.^|boolean
 ^.^|false
-^.^|X
+^.^|-
 ^.^|-
 
 .^|maxTotal
@@ -57,7 +57,7 @@ You can configure the resource with the following options :
 |The maximum number of connections that are supported by the pool.
 ^.^|integer
 ^.^|8
-^.^|X
+^.^|-
 ^.^|-
 
 .^|password
@@ -73,7 +73,7 @@ You can configure the resource with the following options :
 |The maximum number of seconds an element can exist in the cache regardless of use. The element expires at this limit and will no longer be returned from the cache. The default value is 0, which means no timeToLive (TTL) eviction takes place (infinite lifetime).
 ^.^|integer
 ^.^|0
-^.^|X
+^.^|-
 ^.^|-
 
 .^|timeout
@@ -81,7 +81,7 @@ You can configure the resource with the following options :
 |The timeout parameter specifies the connection timeout and the read/write timeout.
 ^.^|integer
 ^.^|2000
-^.^|X
+^.^|-
 ^.^|-
 
 .^|useSsl
@@ -89,7 +89,7 @@ You can configure the resource with the following options :
 | Use SSL connections.
 ^.^|boolean
 ^.^|true
-^.^|X
+^.^|-
 ^.^|-
 
 .^|sentinelMode
@@ -97,7 +97,7 @@ You can configure the resource with the following options :
 |Sentinel provides high availability for Redis. In practical terms this means that using Sentinel you can create a Redis deployment that resists without human intervention certain kinds of failures.
 ^.^|boolean
 ^.^|false
-^.^|X
+^.^|-
 ^.^|-
 
 |===
@@ -120,7 +120,7 @@ You can configure the resource with the following options :
 |The port of the instance.
 ^.^|integer
 ^.^|6379
-^.^|X
+^.^|-
 ^.^|-
 
 |===

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -16,7 +16,7 @@
         },
         "password": {
             "title": "Password",
-            "description": "The password of the instance.",
+            "description": "The password of the instance. (Supports EL and secrets)",
             "type": "string",
             "writeOnly": true
         },
@@ -51,13 +51,13 @@
                         },
                         "host": {
                             "title": "Host",
-                            "description": "The host of the instance",
+                            "description": "The host of the instance. (Supports EL)",
                             "type": "string",
                             "default": "localhost"
                         },
                         "port": {
                             "title": "Port",
-                            "description": "The port of the instance",
+                            "description": "The port of the instance.",
                             "type": "integer",
                             "default": 6379
                         }
@@ -95,13 +95,13 @@
                         },
                         "masterId": {
                             "title": "Master",
-                            "description": "The sentinel master id",
+                            "description": "The sentinel master id. (Supports EL)",
                             "type": "string",
                             "default": "sentinel-master"
                         },
                         "password": {
                             "title": "Sentinel password",
-                            "description": "The sentinel password",
+                            "description": "The sentinel password. (Supports EL and secrets)",
                             "type": "string",
                             "writeOnly": true
                         },


### PR DESCRIPTION
## Issue

add missing information in the form for EL and secret support
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.1-fix-schema-form-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache-redis/4.0.1-fix-schema-form-SNAPSHOT/gravitee-resource-cache-redis-4.0.1-fix-schema-form-SNAPSHOT.zip)
  <!-- Version placeholder end -->
