### PR TITLE
fix: bump lettuce and spring-data-redis dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
 
     <properties>
         <gravitee-apim.version>4.6.0</gravitee-apim.version>
-        <lettuce.version>5.3.7.RELEASE</lettuce.version>
-        <spring-data-redis.version>2.3.4.RELEASE</spring-data-redis.version>
+        <lettuce.version>6.6.0.RELEASE</lettuce.version>
+        <spring-data-redis.version>3.5.6</spring-data-redis.version>
         <commons-pool2.version>2.9.0</commons-pool2.version>
 
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11387

## Description

spring-data-redis 3.5.6 is compatible with 6.2.13 spring framework and 6.6.0.RELEASE lettuce
https://github.com/spring-projects/spring-data-build/blob/59863dd74a650a107ea06e4089a66a1570803f08/parent/pom.xml#L135
https://github.com/spring-projects/spring-data-redis/blob/a88ff9277fbfc3df1c7d70f8edf0f943cb1a62f0/pom.xml#L26

## Additional context