### PR TITLE
fix: remove provided scope from commons-pool2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-pool2</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <!-- Logging -->


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/XXXXX

## Description

commons-pool2 jar must be included in this plugin
otherwise getting this
java.lang.NoClassDefFoundError: org/apache/commons/pool2/impl/GenericObjectPoolConfig
it's not provided by APIM 

## Additional context
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.3-fix-dependency-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache-redis/4.0.3-fix-dependency-SNAPSHOT/gravitee-resource-cache-redis-4.0.3-fix-dependency-SNAPSHOT.zip)
  <!-- Version placeholder end -->
