### PR TITLE
fix(redis-cache): destroy LettuceConnectionFactory on resource stop (APIM-13439)

### DIFF
--- a/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
@@ -53,6 +53,7 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
     private final Logger logger = LoggerFactory.getLogger(RedisCacheResource.class);
     private final StringRedisSerializer stringSerializer = new StringRedisSerializer();
     private RedisCacheManager redisCacheManager;
+    private LettuceConnectionFactory lettuceConnectionFactory;
 
     @Inject
     @Setter
@@ -85,6 +86,17 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
         } catch (Exception e) {
             logger.error("Cannot create redis cache manager", e);
         }
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+        if (lettuceConnectionFactory != null) {
+            logger.debug("Destroying redis connection factory");
+            lettuceConnectionFactory.destroy();
+            lettuceConnectionFactory = null;
+        }
+        redisCacheManager = null;
     }
 
     @Override
@@ -139,7 +151,9 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
     }
 
     public RedisConnectionFactory getConnectionFactory() {
-        final LettuceConnectionFactory lettuceConnectionFactory;
+        if (this.lettuceConnectionFactory != null) {
+            return this.lettuceConnectionFactory;
+        }
         boolean hasSentinelEnabled = configuration().getSentinel().isEnabled();
         if (hasSentinelEnabled || configuration().isSentinelMode()) {
             // Sentinels + Redis master / replicas
@@ -154,7 +168,7 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
             // Redis Password
             sentinelConfiguration.setPassword(RedisPassword.of(configuration().getPassword()));
 
-            lettuceConnectionFactory = new LettuceConnectionFactory(sentinelConfiguration, buildLettuceClientConfiguration());
+            this.lettuceConnectionFactory = new LettuceConnectionFactory(sentinelConfiguration, buildLettuceClientConfiguration());
         } else {
             // Standalone Redis
             RedisStandaloneConfiguration standaloneConfiguration = new RedisStandaloneConfiguration();
@@ -162,11 +176,11 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
             standaloneConfiguration.setPort(configuration().getStandalone().getPort());
             standaloneConfiguration.setPassword(RedisPassword.of(configuration().getPassword()));
 
-            lettuceConnectionFactory = new LettuceConnectionFactory(standaloneConfiguration, buildLettuceClientConfiguration());
+            this.lettuceConnectionFactory = new LettuceConnectionFactory(standaloneConfiguration, buildLettuceClientConfiguration());
         }
 
-        lettuceConnectionFactory.afterPropertiesSet();
+        this.lettuceConnectionFactory.afterPropertiesSet();
 
-        return lettuceConnectionFactory;
+        return this.lettuceConnectionFactory;
     }
 }

--- a/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceTest.java
+++ b/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceTest.java
@@ -28,7 +28,10 @@ import io.gravitee.secrets.api.el.SecretFieldAccessControl;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.*;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 
 /**
  * @author Benoit BORDIGONI (benoit.bordigoni at graviteesource.com)
@@ -113,6 +116,60 @@ class RedisCacheResourceTest {
         RedisCacheResource redisCacheResource = underTest(redisCacheResourceConfiguration);
         redisCacheResource.start();
         assertThat(recordedSecretFieldAccessControls).containsExactlyInAnyOrder(new SecretFieldAccessControl(false, null, null));
+    }
+
+    @Test
+    void should_destroy_connection_factory_on_stop() throws Exception {
+        AtomicBoolean destroyCalled = new AtomicBoolean(false);
+
+        RedisCacheResourceConfiguration config = new RedisCacheResourceConfiguration();
+        RedisCacheResource resource = new RedisCacheResource() {
+            @Override
+            public RedisConnectionFactory getConnectionFactory() {
+                // Call super to go through the real config-based path, then swap the field
+                // with a trackable factory that records destroy() calls
+                super.getConnectionFactory();
+                LettuceConnectionFactory trackable = new LettuceConnectionFactory() {
+                    @Override
+                    public void destroy() {
+                        destroyCalled.set(true);
+                    }
+                };
+                try {
+                    Field f = RedisCacheResource.class.getDeclaredField("lettuceConnectionFactory");
+                    f.setAccessible(true);
+                    f.set(this, trackable);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                return trackable;
+            }
+        };
+        Field configurationField = AbstractConfigurableResource.class.getDeclaredField("configuration");
+        configurationField.setAccessible(true);
+        configurationField.set(resource, config);
+        resource.setDeploymentContext(new TestDeploymentContext(templateEngine));
+
+        resource.start();
+
+        // Verify factory field is populated after start
+        Field factoryField = RedisCacheResource.class.getDeclaredField("lettuceConnectionFactory");
+        factoryField.setAccessible(true);
+        assertThat(factoryField.get(resource)).isNotNull();
+
+        // Verify redisCacheManager is populated after start
+        Field cacheManagerField = RedisCacheResource.class.getDeclaredField("redisCacheManager");
+        cacheManagerField.setAccessible(true);
+        assertThat(cacheManagerField.get(resource)).isNotNull();
+
+        resource.stop();
+
+        // The critical assertion: destroy() must be called to release Netty threads
+        assertThat(destroyCalled.get()).as("destroy() must be called on the connection factory").isTrue();
+
+        // Fields should be cleaned up after stop
+        assertThat(factoryField.get(resource)).isNull();
+        assertThat(cacheManagerField.get(resource)).isNull();
     }
 
     private static String asSecretEL(String password) {


### PR DESCRIPTION
## Summary

- `RedisCacheResource.getConnectionFactory()` created a `LettuceConnectionFactory` as a local variable with no cleanup. Every API redeploy orphaned the old factory, leaking the Lettuce client, Netty event loops, and connection pool indefinitely.
- Fix stores the factory as an instance field, adds an idempotency guard in `getConnectionFactory()` to reuse it across calls, and adds `doStop()` to call `lettuceConnectionFactory.destroy()` on resource stop.
- Test added to verify `destroy()` is actually called on stop (not just field nulling).

Fixes APIM-13439.

## Test plan

- [ ] `RedisCacheResourceTest` — all 4 tests pass
- [ ] Verify: repeated API redeployments no longer accumulate leaked threads
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.4-fix-APIM-13439-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache-redis/4.0.4-fix-APIM-13439-SNAPSHOT/gravitee-resource-cache-redis-4.0.4-fix-APIM-13439-SNAPSHOT.zip)
  <!-- Version placeholder end -->
