### PR TITLE
feat(redis-cache): share LettuceConnectionFactory across APIs

### DIFF
--- a/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
@@ -54,6 +54,7 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
     private final StringRedisSerializer stringSerializer = new StringRedisSerializer();
     private RedisCacheManager redisCacheManager;
     private LettuceConnectionFactory lettuceConnectionFactory;
+    private String connectionFactoryKey;
 
     @Inject
     @Setter
@@ -91,9 +92,10 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
     @Override
     protected void doStop() throws Exception {
         super.doStop();
-        if (lettuceConnectionFactory != null) {
-            logger.debug("Destroying redis connection factory");
-            lettuceConnectionFactory.destroy();
+        if (connectionFactoryKey != null) {
+            logger.debug("Releasing shared redis connection factory for key [{}]", connectionFactoryKey);
+            SharedConnectionFactoryRegistry.INSTANCE.release(connectionFactoryKey);
+            connectionFactoryKey = null;
             lettuceConnectionFactory = null;
         }
         redisCacheManager = null;
@@ -154,32 +156,32 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
         if (this.lettuceConnectionFactory != null) {
             return this.lettuceConnectionFactory;
         }
+
         boolean hasSentinelEnabled = configuration().getSentinel().isEnabled();
-        if (hasSentinelEnabled || configuration().isSentinelMode()) {
-            // Sentinels + Redis master / replicas
-            List<HostAndPort> sentinelNodes = configuration().getSentinel().getNodes();
+        boolean isSentinel = hasSentinelEnabled || configuration().isSentinelMode();
 
-            RedisSentinelConfiguration sentinelConfiguration = new RedisSentinelConfiguration();
-            sentinelConfiguration.master(configuration().getSentinel().getMasterId());
-            // Parsing and registering nodes
-            sentinelNodes.forEach(hostAndPort -> sentinelConfiguration.sentinel(hostAndPort.getHost(), hostAndPort.getPort()));
-            // Sentinel Password
-            sentinelConfiguration.setSentinelPassword(RedisPassword.of(configuration().getSentinel().getPassword()));
-            // Redis Password
-            sentinelConfiguration.setPassword(RedisPassword.of(configuration().getPassword()));
+        this.connectionFactoryKey = SharedConnectionFactoryRegistry.buildKey(configuration());
 
-            this.lettuceConnectionFactory = new LettuceConnectionFactory(sentinelConfiguration, buildLettuceClientConfiguration());
-        } else {
-            // Standalone Redis
-            RedisStandaloneConfiguration standaloneConfiguration = new RedisStandaloneConfiguration();
-            standaloneConfiguration.setHostName(configuration().getStandalone().getHost());
-            standaloneConfiguration.setPort(configuration().getStandalone().getPort());
-            standaloneConfiguration.setPassword(RedisPassword.of(configuration().getPassword()));
-
-            this.lettuceConnectionFactory = new LettuceConnectionFactory(standaloneConfiguration, buildLettuceClientConfiguration());
-        }
-
-        this.lettuceConnectionFactory.afterPropertiesSet();
+        this.lettuceConnectionFactory = SharedConnectionFactoryRegistry.INSTANCE.acquire(connectionFactoryKey, () -> {
+            LettuceConnectionFactory factory;
+            if (isSentinel) {
+                List<HostAndPort> sentinelNodes = configuration().getSentinel().getNodes();
+                RedisSentinelConfiguration sentinelConfiguration = new RedisSentinelConfiguration();
+                sentinelConfiguration.master(configuration().getSentinel().getMasterId());
+                sentinelNodes.forEach(hostAndPort -> sentinelConfiguration.sentinel(hostAndPort.getHost(), hostAndPort.getPort()));
+                sentinelConfiguration.setSentinelPassword(RedisPassword.of(configuration().getSentinel().getPassword()));
+                sentinelConfiguration.setPassword(RedisPassword.of(configuration().getPassword()));
+                factory = new LettuceConnectionFactory(sentinelConfiguration, buildLettuceClientConfiguration());
+            } else {
+                RedisStandaloneConfiguration standaloneConfiguration = new RedisStandaloneConfiguration();
+                standaloneConfiguration.setHostName(configuration().getStandalone().getHost());
+                standaloneConfiguration.setPort(configuration().getStandalone().getPort());
+                standaloneConfiguration.setPassword(RedisPassword.of(configuration().getPassword()));
+                factory = new LettuceConnectionFactory(standaloneConfiguration, buildLettuceClientConfiguration());
+            }
+            factory.afterPropertiesSet();
+            return factory;
+        });
 
         return this.lettuceConnectionFactory;
     }

--- a/src/main/java/io/gravitee/resource/cache/redis/SharedConnectionFactoryRegistry.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/SharedConnectionFactoryRegistry.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.cache.redis;
+
+import io.gravitee.resource.cache.redis.configuration.RedisCacheResourceConfiguration;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+/**
+ * Shares a single {@link LettuceConnectionFactory} across all {@link RedisCacheResource} instances
+ * that connect to the same Redis endpoint. This avoids creating one persistent connection per API
+ * when thousands of APIs use the same Redis cache resource configuration.
+ *
+ * <p>Thread-safe. Keyed by connection parameters (host, port, password, ssl, sentinel config).
+ * Uses reference counting: factory is created on first acquire, destroyed when last reference is released.
+ */
+@Slf4j
+class SharedConnectionFactoryRegistry {
+
+    static final SharedConnectionFactoryRegistry INSTANCE = new SharedConnectionFactoryRegistry();
+
+    private final ConcurrentHashMap<String, RefCountedFactory> factories = new ConcurrentHashMap<>();
+
+    /**
+     * Acquire a shared factory for the given key. If none exists, creates one using the supplier.
+     */
+    LettuceConnectionFactory acquire(String key, Supplier<LettuceConnectionFactory> factorySupplier) {
+        RefCountedFactory ref = factories.compute(key, (k, existing) -> {
+            if (existing != null) {
+                existing.refCount.incrementAndGet();
+                log.debug("Reusing shared connection factory for key [{}], refCount={}", k, existing.refCount.get());
+                return existing;
+            }
+            LettuceConnectionFactory factory = factorySupplier.get();
+            log.info("Created shared connection factory for key [{}]", k);
+            return new RefCountedFactory(factory);
+        });
+        return ref.factory;
+    }
+
+    /**
+     * Release a reference to the shared factory. When the last reference is released,
+     * the factory is destroyed and removed from the registry.
+     */
+    void release(String key) {
+        factories.compute(key, (k, existing) -> {
+            if (existing == null) {
+                log.warn("Attempted to release unknown connection factory key [{}]", k);
+                return null;
+            }
+            int remaining = existing.refCount.decrementAndGet();
+            if (remaining <= 0) {
+                log.info("Destroying shared connection factory for key [{}] (last reference released)", k);
+                try {
+                    existing.factory.destroy();
+                } catch (Exception e) {
+                    log.warn("Error destroying shared connection factory for key [{}]", k, e);
+                }
+                return null; // remove from map
+            }
+            log.debug("Released shared connection factory for key [{}], refCount={}", k, remaining);
+            return existing;
+        });
+    }
+
+    /**
+     * Build a registry key from connection parameters.
+     * All resources pointing to the same Redis share one factory.
+     */
+    static String buildKey(RedisCacheResourceConfiguration config) {
+        StringBuilder sb = new StringBuilder();
+        boolean isSentinel = config.getSentinel().isEnabled() || config.isSentinelMode();
+
+        if (isSentinel) {
+            sb.append("sentinel|");
+            sb.append(Objects.toString(config.getSentinel().getMasterId(), ""));
+            sb.append("|");
+            config
+                .getSentinel()
+                .getNodes()
+                .forEach(node -> {
+                    sb.append(node.getHost()).append(":").append(node.getPort()).append(",");
+                });
+            sb.append("|");
+            sb.append(Objects.toString(config.getSentinel().getPassword(), ""));
+        } else {
+            sb.append("standalone|");
+            sb.append(Objects.toString(config.getStandalone().getHost(), ""));
+            sb.append(":");
+            sb.append(config.getStandalone().getPort());
+        }
+
+        sb.append("|");
+        sb.append(Objects.toString(config.getPassword(), ""));
+        sb.append("|ssl=");
+        sb.append(config.isUseSsl());
+
+        return sb.toString();
+    }
+
+    // Visible for testing
+    int registrySize() {
+        return factories.size();
+    }
+
+    private static class RefCountedFactory {
+
+        final LettuceConnectionFactory factory;
+        final AtomicInteger refCount;
+
+        RefCountedFactory(LettuceConnectionFactory factory) {
+            this.factory = factory;
+            this.refCount = new AtomicInteger(1);
+        }
+    }
+}

--- a/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceTest.java
+++ b/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceTest.java
@@ -28,10 +28,7 @@ import io.gravitee.secrets.api.el.SecretFieldAccessControl;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.*;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 
 /**
  * @author Benoit BORDIGONI (benoit.bordigoni at graviteesource.com)
@@ -119,36 +116,9 @@ class RedisCacheResourceTest {
     }
 
     @Test
-    void should_destroy_connection_factory_on_stop() throws Exception {
-        AtomicBoolean destroyCalled = new AtomicBoolean(false);
-
+    void should_release_shared_factory_on_stop() throws Exception {
         RedisCacheResourceConfiguration config = new RedisCacheResourceConfiguration();
-        RedisCacheResource resource = new RedisCacheResource() {
-            @Override
-            public RedisConnectionFactory getConnectionFactory() {
-                // Call super to go through the real config-based path, then swap the field
-                // with a trackable factory that records destroy() calls
-                super.getConnectionFactory();
-                LettuceConnectionFactory trackable = new LettuceConnectionFactory() {
-                    @Override
-                    public void destroy() {
-                        destroyCalled.set(true);
-                    }
-                };
-                try {
-                    Field f = RedisCacheResource.class.getDeclaredField("lettuceConnectionFactory");
-                    f.setAccessible(true);
-                    f.set(this, trackable);
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-                return trackable;
-            }
-        };
-        Field configurationField = AbstractConfigurableResource.class.getDeclaredField("configuration");
-        configurationField.setAccessible(true);
-        configurationField.set(resource, config);
-        resource.setDeploymentContext(new TestDeploymentContext(templateEngine));
+        RedisCacheResource resource = underTest(config);
 
         resource.start();
 
@@ -157,19 +127,50 @@ class RedisCacheResourceTest {
         factoryField.setAccessible(true);
         assertThat(factoryField.get(resource)).isNotNull();
 
-        // Verify redisCacheManager is populated after start
-        Field cacheManagerField = RedisCacheResource.class.getDeclaredField("redisCacheManager");
-        cacheManagerField.setAccessible(true);
-        assertThat(cacheManagerField.get(resource)).isNotNull();
+        // Verify connectionFactoryKey is set
+        Field keyField = RedisCacheResource.class.getDeclaredField("connectionFactoryKey");
+        keyField.setAccessible(true);
+        assertThat(keyField.get(resource)).isNotNull();
+
+        // Registry should have 1 entry
+        assertThat(SharedConnectionFactoryRegistry.INSTANCE.registrySize()).isEqualTo(1);
 
         resource.stop();
 
-        // The critical assertion: destroy() must be called to release Netty threads
-        assertThat(destroyCalled.get()).as("destroy() must be called on the connection factory").isTrue();
-
         // Fields should be cleaned up after stop
         assertThat(factoryField.get(resource)).isNull();
-        assertThat(cacheManagerField.get(resource)).isNull();
+        assertThat(keyField.get(resource)).isNull();
+
+        // Registry should be empty (last reference released)
+        assertThat(SharedConnectionFactoryRegistry.INSTANCE.registrySize()).isZero();
+    }
+
+    @Test
+    void should_share_factory_between_two_resources_with_same_config() throws Exception {
+        RedisCacheResourceConfiguration config1 = new RedisCacheResourceConfiguration();
+        RedisCacheResourceConfiguration config2 = new RedisCacheResourceConfiguration();
+
+        RedisCacheResource resource1 = underTest(config1);
+        RedisCacheResource resource2 = underTest(config2);
+
+        resource1.start();
+        resource2.start();
+
+        // Both should share the same factory instance
+        Field factoryField = RedisCacheResource.class.getDeclaredField("lettuceConnectionFactory");
+        factoryField.setAccessible(true);
+        assertThat(factoryField.get(resource1)).isSameAs(factoryField.get(resource2));
+
+        // Registry should have 1 entry (shared)
+        assertThat(SharedConnectionFactoryRegistry.INSTANCE.registrySize()).isEqualTo(1);
+
+        // Stop first resource — factory should stay (still referenced by resource2)
+        resource1.stop();
+        assertThat(SharedConnectionFactoryRegistry.INSTANCE.registrySize()).isEqualTo(1);
+
+        // Stop second resource — factory should be destroyed
+        resource2.stop();
+        assertThat(SharedConnectionFactoryRegistry.INSTANCE.registrySize()).isZero();
     }
 
     private static String asSecretEL(String password) {


### PR DESCRIPTION
## Summary

Share a single `LettuceConnectionFactory` across all APIs that connect to the same Redis, instead of creating one per API.

Fixes [APIM-13553](https://gravitee.atlassian.net/browse/APIM-13553)

## Problem

Each API with a Redis cache resource creates its own `LettuceConnectionFactory` with a persistent shared native connection. At scale (5000+ APIs), this means 5000+ Redis connections per gateway, hitting Redis `maxclients` limits.

## Solution

New `SharedConnectionFactoryRegistry` manages factories with reference counting, keyed by connection params (host, port, password, ssl, sentinel config). All APIs pointing to the same Redis share one factory and one connection.

- 10 APIs, same Redis config = 1 connection (was 10)
- 5000 APIs, same Redis config = 1 connection (was 5000)

## Changes

- `SharedConnectionFactoryRegistry.java` (new): static singleton registry with `ConcurrentHashMap`, ref counting, keyed by `RedisCacheResourceConfiguration`
- `RedisCacheResource.java`: `getConnectionFactory()` acquires from registry, `doStop()` releases. `buildLettuceClientConfiguration()` unchanged.
- `RedisCacheResourceTest.java`: tests for single resource lifecycle and two resources sharing one factory

## What's NOT changed

- `RedisCacheResourceConfiguration.java`: no fields added or removed
- `schema-form.json`: no UI changes
- `LettucePoolingClientConfiguration`: identical config (commandTimeout, useSsl, maxTotal, blockWhenExhausted)
- Redis key/value format: identical, upgrade safe

## Test plan

- [x] 5/5 unit tests pass
- [x] 10 APIs with same Redis config = 1 Lettuce connection after warmup
- [x] 50 concurrent users across 10 APIs for 30s = still 1 connection
- [x] Unfixed plugin (4.0.4) same test = 11 connections
- [x] All APIs return HTTP 200 during load test

[APIM-13553]: https://gravitee.atlassian.net/browse/APIM-13553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.0-feat-shared-connection-factory-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache-redis/4.1.0-feat-shared-connection-factory-SNAPSHOT/gravitee-resource-cache-redis-4.1.0-feat-shared-connection-factory-SNAPSHOT.zip)
  <!-- Version placeholder end -->
