### PR TITLE
feat(redis-cache): rewrite with Vert.x Redis client (APIM-13556)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,7 @@
     <description>The resource is used to maintain a cache and link it to the API lifecycle. Redis provides a different range of persistence options, it means that the cache can keep data after reboot.</description>
 
     <properties>
-        <gravitee-apim.version>4.9.5</gravitee-apim.version>
-        <lettuce.version>6.6.0.RELEASE</lettuce.version>
-        <spring-data-redis.version>3.5.6</spring-data-redis.version>
+        <gravitee-apim.version>4.9.17-SNAPSHOT</gravitee-apim.version>
 
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
 
@@ -97,9 +95,20 @@
         </dependency>
 
         <dependency>
-            <groupId>io.lettuce</groupId>
-            <artifactId>lettuce-core</artifactId>
-            <version>${lettuce.version}</version>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-redis-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.vertx</groupId>
+                    <artifactId>vertx-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -130,12 +139,6 @@
 
         <!-- Spring -->
         <dependency>
-            <groupId>org.springframework.data</groupId>
-            <artifactId>spring-data-redis</artifactId>
-            <version>${spring-data-redis.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
             <scope>provided</scope>
@@ -145,11 +148,6 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-pool2</artifactId>
         </dependency>
 
         <!-- Logging -->
@@ -171,6 +169,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
             <scope>test</scope>
@@ -178,6 +181,21 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
@@ -24,42 +24,38 @@ import io.gravitee.resource.cache.api.CacheResource;
 import io.gravitee.resource.cache.redis.configuration.HostAndPort;
 import io.gravitee.resource.cache.redis.configuration.RedisCacheResourceConfiguration;
 import io.gravitee.resource.cache.redis.configuration.RedisCacheResourceConfigurationEvaluator;
-import io.lettuce.core.api.StatefulConnection;
-import java.time.Duration;
-import java.util.List;
+import io.vertx.core.Vertx;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisAPI;
+import io.vertx.redis.client.RedisClientType;
+import io.vertx.redis.client.RedisOptions;
+import io.vertx.redis.client.RedisRole;
 import java.util.Map;
 import javax.inject.Inject;
 import lombok.Setter;
-import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.data.redis.cache.RedisCacheConfiguration;
-import org.springframework.data.redis.cache.RedisCacheManager;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.RedisPassword;
-import org.springframework.data.redis.connection.RedisSentinelConfiguration;
-import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.connection.lettuce.LettucePoolingClientConfiguration;
-import org.springframework.data.redis.serializer.RedisSerializationContext;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.env.Environment;
 
 /**
  * @author Guillaume CUSNIEUX (guillaume.cusnieux at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class RedisCacheResource extends CacheResource<RedisCacheResourceConfiguration> {
+@Slf4j
+public class RedisCacheResource extends CacheResource<RedisCacheResourceConfiguration> implements ApplicationContextAware {
 
-    private final Logger logger = LoggerFactory.getLogger(RedisCacheResource.class);
-    private final StringRedisSerializer stringSerializer = new StringRedisSerializer();
-    private RedisCacheManager redisCacheManager;
-    private LettuceConnectionFactory lettuceConnectionFactory;
+    @Setter
+    private ApplicationContext applicationContext;
 
     @Inject
     @Setter
     private DeploymentContext deploymentContext;
 
     private RedisCacheResourceConfiguration configuration;
+    private volatile Redis redisClient;
+    private volatile RedisAPI redisAPI;
+    private String registryKey;
 
     @Override
     public RedisCacheResourceConfiguration configuration() {
@@ -72,31 +68,40 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
     @Override
     protected void doStart() throws Exception {
         super.doStart();
-        logger.debug("Create redis cache manager");
+        log.debug("Create redis cache resource");
 
         configuration = new RedisCacheResourceConfigurationEvaluator(configuration()).evalNow(deploymentContext);
 
-        try {
-            RedisCacheConfiguration conf = RedisCacheConfiguration.defaultCacheConfig()
-                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(stringSerializer))
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(stringSerializer))
-                .entryTtl(Duration.ofSeconds(configuration().getTimeToLiveSeconds()));
+        Vertx vertx = applicationContext.getBean(Vertx.class);
 
-            this.redisCacheManager = RedisCacheManager.builder(getConnectionFactory()).cacheDefaults(conf).build();
+        registryKey = SharedRedisClientRegistry.buildKey(configuration);
+
+        redisClient = SharedRedisClientRegistry.INSTANCE.acquire(registryKey, () -> {
+            RedisOptions options = buildRedisOptions();
+            return Redis.createClient(vertx, options);
+        });
+
+        try {
+            redisAPI = RedisAPI.api(redisClient);
         } catch (Exception e) {
-            logger.error("Cannot create redis cache manager", e);
+            // Ensure we don't leak a refcount if anything after acquire() fails
+            SharedRedisClientRegistry.INSTANCE.release(registryKey);
+            registryKey = null;
+            redisClient = null;
+            throw e;
         }
     }
 
     @Override
     protected void doStop() throws Exception {
         super.doStop();
-        if (lettuceConnectionFactory != null) {
-            logger.debug("Destroying redis connection factory");
-            lettuceConnectionFactory.destroy();
-            lettuceConnectionFactory = null;
+        if (registryKey != null) {
+            log.debug("Releasing shared Redis client for key [{}]", registryKey);
+            SharedRedisClientRegistry.INSTANCE.release(registryKey);
+            registryKey = null;
+            redisClient = null;
+            redisAPI = null;
         }
-        redisCacheManager = null;
     }
 
     @Override
@@ -128,59 +133,67 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
 
     private Cache getCache(Map<String, Object> contextAttributes) {
         return new RedisDelegate(
-            this.redisCacheManager.getCache("gravitee:"),
+            redisAPI,
+            "gravitee:",
             contextAttributes,
-            stringSerializer,
             (int) configuration().getTimeToLiveSeconds(),
-            configuration().isReleaseCache()
+            configuration().isReleaseCache(),
+            configuration().getTimeout()
         );
     }
 
-    private LettucePoolingClientConfiguration buildLettuceClientConfiguration() {
-        final LettucePoolingClientConfiguration.LettucePoolingClientConfigurationBuilder builder =
-            LettucePoolingClientConfiguration.builder();
-        builder.commandTimeout(Duration.ofMillis(configuration().getTimeout()));
-        if (configuration().isUseSsl()) {
-            builder.useSsl();
+    private RedisOptions buildRedisOptions() {
+        RedisOptions options = new RedisOptions();
+        boolean ssl = configuration.isUseSsl();
+        boolean isSentinel = configuration.getSentinel().isEnabled() || configuration.isSentinelMode();
+
+        if (isSentinel) {
+            options.setType(RedisClientType.SENTINEL);
+            for (HostAndPort node : configuration.getSentinel().getNodes()) {
+                options.addConnectionString(buildConnectionString(node.getHost(), node.getPort(), ssl));
+            }
+            options.setMasterName(configuration.getSentinel().getMasterId());
+            options.setRole(RedisRole.MASTER);
+            String sentinelPassword = configuration.getSentinel().getPassword();
+            if (sentinelPassword != null && !sentinelPassword.isEmpty()) {
+                options.setPassword(sentinelPassword);
+            }
+        } else {
+            options.setType(RedisClientType.STANDALONE);
+            options.setConnectionString(
+                buildConnectionString(configuration.getStandalone().getHost(), configuration.getStandalone().getPort(), ssl)
+            );
+            String password = configuration.getPassword();
+            if (password != null && !password.isEmpty()) {
+                options.setPassword(password);
+            }
         }
-        GenericObjectPoolConfig<StatefulConnection<?, ?>> poolConfig = new GenericObjectPoolConfig<>();
-        poolConfig.setMaxTotal(configuration().getMaxTotal());
-        poolConfig.setBlockWhenExhausted(false);
-        builder.poolConfig(poolConfig);
-        return builder.build();
+
+        if (ssl) {
+            options.getNetClientOptions().setSsl(true).setTrustAll(true);
+            options.getNetClientOptions().setHostnameVerificationAlgorithm("");
+        }
+
+        // Pool config from gravitee.yml
+        Environment env = applicationContext.getBean(Environment.class);
+        int maxPoolSize = env.getProperty("redis.configurations.default.maxPoolSize", Integer.class, 6);
+        int cleanerInterval = env.getProperty("redis.configurations.default.poolCleanerInterval", Integer.class, 30000);
+        int recycleTimeout = env.getProperty("redis.configurations.default.poolRecycleTimeout", Integer.class, 180000);
+
+        options.setMaxPoolSize(maxPoolSize);
+        options.setPoolCleanerInterval(cleanerInterval);
+        options.setPoolRecycleTimeout(recycleTimeout);
+        options.setMaxWaitingHandlers(1024);
+
+        // Connection timeout from gravitee.yml
+        int connectTimeout = env.getProperty("redis.configurations.default.connectTimeout", Integer.class, 2000);
+        options.getNetClientOptions().setConnectTimeout(connectTimeout);
+
+        return options;
     }
 
-    public RedisConnectionFactory getConnectionFactory() {
-        if (this.lettuceConnectionFactory != null) {
-            return this.lettuceConnectionFactory;
-        }
-        boolean hasSentinelEnabled = configuration().getSentinel().isEnabled();
-        if (hasSentinelEnabled || configuration().isSentinelMode()) {
-            // Sentinels + Redis master / replicas
-            List<HostAndPort> sentinelNodes = configuration().getSentinel().getNodes();
-
-            RedisSentinelConfiguration sentinelConfiguration = new RedisSentinelConfiguration();
-            sentinelConfiguration.master(configuration().getSentinel().getMasterId());
-            // Parsing and registering nodes
-            sentinelNodes.forEach(hostAndPort -> sentinelConfiguration.sentinel(hostAndPort.getHost(), hostAndPort.getPort()));
-            // Sentinel Password
-            sentinelConfiguration.setSentinelPassword(RedisPassword.of(configuration().getSentinel().getPassword()));
-            // Redis Password
-            sentinelConfiguration.setPassword(RedisPassword.of(configuration().getPassword()));
-
-            this.lettuceConnectionFactory = new LettuceConnectionFactory(sentinelConfiguration, buildLettuceClientConfiguration());
-        } else {
-            // Standalone Redis
-            RedisStandaloneConfiguration standaloneConfiguration = new RedisStandaloneConfiguration();
-            standaloneConfiguration.setHostName(configuration().getStandalone().getHost());
-            standaloneConfiguration.setPort(configuration().getStandalone().getPort());
-            standaloneConfiguration.setPassword(RedisPassword.of(configuration().getPassword()));
-
-            this.lettuceConnectionFactory = new LettuceConnectionFactory(standaloneConfiguration, buildLettuceClientConfiguration());
-        }
-
-        this.lettuceConnectionFactory.afterPropertiesSet();
-
-        return this.lettuceConnectionFactory;
+    static String buildConnectionString(String host, int port, boolean ssl) {
+        String scheme = ssl ? "rediss" : "redis";
+        return scheme + "://" + host + ":" + port;
     }
 }

--- a/src/main/java/io/gravitee/resource/cache/redis/RedisDelegate.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/RedisDelegate.java
@@ -18,12 +18,16 @@ package io.gravitee.resource.cache.redis;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.resource.cache.api.Cache;
 import io.gravitee.resource.cache.api.Element;
-import java.time.Duration;
+import io.vertx.core.Future;
+import io.vertx.redis.client.RedisAPI;
+import io.vertx.redis.client.Response;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.cache.RedisCacheWriter;
-import org.springframework.data.redis.serializer.RedisSerializer;
 
 /**
  * @author Guillaume CUSNIEUX (guillaume.cusnieux at graviteesource.com)
@@ -33,86 +37,141 @@ import org.springframework.data.redis.serializer.RedisSerializer;
 @RequiredArgsConstructor
 public class RedisDelegate implements Cache {
 
-    private final org.springframework.cache.Cache cache;
+    private final RedisAPI redisAPI;
+    private final String cacheName;
     private final Map<String, Object> contextAttributes;
-    private final RedisSerializer<String> serializer;
     private final int timeToLiveSeconds;
     private final boolean releaseCache;
+    private final long commandTimeoutMs;
 
     @Override
     public String getName() {
-        return this.cache.getName();
+        return this.cacheName;
     }
 
     @Override
     public Object getNativeCache() {
-        return cache.getNativeCache();
+        return redisAPI;
     }
 
     @Override
     public Element get(Object key) {
         log.debug("Find in cache {}", key);
-        try {
-            RedisCacheWriter redisCacheWriter = (RedisCacheWriter) this.getNativeCache();
-            byte[] bytes = redisCacheWriter.get(this.getName(), buildKey(key));
-            if (bytes != null) {
-                Object value = this.serializer.deserialize(bytes);
-                return new Element() {
-                    @Override
-                    public Object key() {
-                        return key;
-                    }
-
-                    @Override
-                    public Object value() {
-                        return value;
-                    }
-                };
-            }
-            return null;
-        } catch (Exception e) {
-            log.error("Cannot get element in cache", e);
-        }
-        log.debug("Not found {}", key);
-        return null;
+        return awaitBlocking(getAsync(key), "get");
     }
 
     @Override
     public void put(Element element) {
         log.debug("Put in cache {}", element.key());
-        try {
-            int ttl = this.timeToLiveSeconds;
-            if ((ttl == 0 && element.timeToLive() > 0) || (ttl > 0 && element.timeToLive() > 0 && ttl > element.timeToLive())) {
-                ttl = element.timeToLive();
-            }
-            RedisCacheWriter redisCacheWriter = (RedisCacheWriter) this.getNativeCache();
-
-            redisCacheWriter.put(
-                getName(),
-                buildKey(element.key()),
-                this.serializer.serialize((String) element.value()),
-                Duration.ofSeconds(ttl)
-            );
-        } catch (Exception e) {
-            log.error("Cannot put element in cache", e);
-        }
-    }
-
-    private byte[] buildKey(Object key) {
-        String allKey = this.getName() + key;
-        if (this.releaseCache) {
-            allKey += ":" + contextAttributes.get(ExecutionContext.ATTR_API_DEPLOYED_AT);
-        }
-        return this.serializer.serialize(allKey);
+        awaitBlocking(putAsync(element), "put");
     }
 
     @Override
     public void evict(Object o) {
-        cache.evict(o);
+        log.debug("Evict from cache {}", o);
+        awaitBlocking(evictAsync(o), "evict");
     }
 
     @Override
     public void clear() {
-        cache.clear();
+        log.debug("Clear cache {}", cacheName);
+        awaitBlocking(clearAsync(), "clear");
+    }
+
+    @Override
+    public Future<Element> getAsync(Object key) {
+        String redisKey = buildKey(key);
+        return redisAPI
+            .get(redisKey)
+            .timeout(commandTimeoutMs, TimeUnit.MILLISECONDS)
+            .map(response -> response != null ? toElement(key, response.toString()) : null);
+    }
+
+    @Override
+    public Future<Void> putAsync(Element element) {
+        int ttl = resolveTtl(element);
+        String redisKey = buildKey(element.key());
+        String value = (String) element.value();
+        Future<Response> future;
+        if (ttl > 0) {
+            future = redisAPI.setex(redisKey, String.valueOf(ttl), value);
+        } else {
+            future = redisAPI.set(List.of(redisKey, value));
+        }
+        return future.timeout(commandTimeoutMs, TimeUnit.MILLISECONDS).mapEmpty();
+    }
+
+    @Override
+    public Future<Void> evictAsync(Object key) {
+        String redisKey = buildKey(key);
+        return redisAPI.del(List.of(redisKey)).timeout(commandTimeoutMs, TimeUnit.MILLISECONDS).mapEmpty();
+    }
+
+    @Override
+    public Future<Void> clearAsync() {
+        return scanAndDelete("0", cacheName + "*");
+    }
+
+    private Future<Void> scanAndDelete(String cursor, String pattern) {
+        return redisAPI
+            .scan(List.of(cursor, "MATCH", pattern, "COUNT", "100"))
+            .timeout(commandTimeoutMs, TimeUnit.MILLISECONDS)
+            .compose(scanResult -> {
+                String nextCursor = scanResult.get(0).toString();
+                Response keys = scanResult.get(1);
+                Future<Void> deleteFuture = Future.succeededFuture();
+                if (keys != null && keys.size() > 0) {
+                    List<String> keyList = new ArrayList<>(keys.size());
+                    for (Response k : keys) {
+                        keyList.add(k.toString());
+                    }
+                    deleteFuture = redisAPI.del(keyList).timeout(commandTimeoutMs, TimeUnit.MILLISECONDS).mapEmpty();
+                }
+                if ("0".equals(nextCursor)) {
+                    return deleteFuture;
+                }
+                return deleteFuture.compose(v -> scanAndDelete(nextCursor, pattern));
+            });
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T awaitBlocking(Future<T> future, String op) {
+        try {
+            return (T) future.toCompletionStage().toCompletableFuture().join();
+        } catch (CompletionException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            log.error("[redis-cache-{}] Redis {} operation failed: {}", op, op, cause.getMessage(), cause);
+            return null;
+        }
+    }
+
+    private String buildKey(Object key) {
+        String fullKey = cacheName + key;
+        if (releaseCache) {
+            fullKey += ":" + contextAttributes.get(ExecutionContext.ATTR_API_DEPLOYED_AT);
+        }
+        return fullKey;
+    }
+
+    private int resolveTtl(Element element) {
+        int ttl = timeToLiveSeconds;
+        if ((ttl == 0 && element.timeToLive() > 0) || (ttl > 0 && element.timeToLive() > 0 && ttl > element.timeToLive())) {
+            ttl = element.timeToLive();
+        }
+        return ttl;
+    }
+
+    private static Element toElement(Object key, String value) {
+        return new Element() {
+            @Override
+            public Object key() {
+                return key;
+            }
+
+            @Override
+            public Object value() {
+                return value;
+            }
+        };
     }
 }

--- a/src/main/java/io/gravitee/resource/cache/redis/SharedRedisClientRegistry.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/SharedRedisClientRegistry.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.cache.redis;
+
+import io.gravitee.resource.cache.redis.configuration.HostAndPort;
+import io.gravitee.resource.cache.redis.configuration.RedisCacheResourceConfiguration;
+import io.vertx.redis.client.Redis;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Shares a single Vert.x {@link Redis} client across all {@link RedisCacheResource} instances
+ * that connect to the same Redis endpoint. This avoids creating one connection per API
+ * when thousands of APIs use the same Redis cache resource configuration.
+ *
+ * <p>Thread-safe. Keyed by connection parameters (host, port, password, ssl, sentinel config).
+ * Uses reference counting: client is created on first acquire, closed when last reference is released.
+ */
+@Slf4j
+class SharedRedisClientRegistry {
+
+    static final SharedRedisClientRegistry INSTANCE = new SharedRedisClientRegistry();
+
+    private final ConcurrentHashMap<String, RefCountedClient> clients = new ConcurrentHashMap<>();
+
+    /**
+     * Acquire a shared Redis client for the given key. If none exists, creates one using the supplier.
+     */
+    Redis acquire(String key, Supplier<Redis> clientSupplier) {
+        RefCountedClient ref = clients.compute(key, (k, existing) -> {
+            if (existing != null) {
+                existing.refCount.incrementAndGet();
+                log.debug("Reusing shared Redis client, refCount={}, registrySize={}", existing.refCount.get(), clients.size());
+                return existing;
+            }
+            Redis client = clientSupplier.get();
+            log.info("Created new shared Redis client, registrySize={}", clients.size() + 1);
+            return new RefCountedClient(client);
+        });
+        return ref.client;
+    }
+
+    /**
+     * Release a reference to the shared client. When the last reference is released,
+     * the client is closed and removed from the registry.
+     */
+    void release(String key) {
+        clients.compute(key, (k, existing) -> {
+            if (existing == null) {
+                log.error("Attempted to release unknown Redis client for key [{}] (double-release bug)", key);
+                return null;
+            }
+            int remaining = existing.refCount.decrementAndGet();
+            if (remaining <= 0) {
+                log.info("Closing shared Redis client (last reference released), registrySize={}", clients.size() - 1);
+                try {
+                    existing.client.close();
+                } catch (Exception e) {
+                    log.warn("Error closing shared Redis client", e);
+                }
+                return null; // remove from map
+            }
+            log.debug("Released shared Redis client, refCount={}, registrySize={}", remaining, clients.size());
+            return existing;
+        });
+    }
+
+    /**
+     * Build a registry key from connection parameters.
+     * All resources pointing to the same Redis share one client.
+     */
+    static String buildKey(RedisCacheResourceConfiguration config) {
+        StringBuilder sb = new StringBuilder();
+        boolean isSentinel = config.getSentinel().isEnabled() || config.isSentinelMode();
+
+        if (isSentinel) {
+            sb.append("sentinel|");
+            sb.append(Objects.toString(config.getSentinel().getMasterId(), ""));
+            sb.append("|");
+            List<HostAndPort> sortedNodes = new ArrayList<>(config.getSentinel().getNodes());
+            sortedNodes.sort(Comparator.comparing(HostAndPort::getHost).thenComparingInt(HostAndPort::getPort));
+            for (HostAndPort node : sortedNodes) {
+                sb.append(node.getHost()).append(":").append(node.getPort()).append(",");
+            }
+            sb.append("|");
+            sb.append(Objects.toString(config.getSentinel().getPassword(), ""));
+        } else {
+            sb.append("standalone|");
+            sb.append(Objects.toString(config.getStandalone().getHost(), ""));
+            sb.append(":");
+            sb.append(config.getStandalone().getPort());
+        }
+
+        sb.append("|");
+        sb.append(Objects.toString(config.getPassword(), ""));
+        sb.append("|ssl=");
+        sb.append(config.isUseSsl());
+
+        return sb.toString();
+    }
+
+    // Visible for testing
+    int registrySize() {
+        return clients.size();
+    }
+
+    private static class RefCountedClient {
+
+        final Redis client;
+        final AtomicInteger refCount;
+
+        RefCountedClient(Redis client) {
+            this.client = client;
+            this.refCount = new AtomicInteger(1);
+        }
+    }
+}

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -8,12 +8,6 @@
             "type": "boolean",
             "default": false
         },
-        "maxTotal": {
-            "title": "Max total",
-            "description": "The maximum number of connections that are supported by the pool.",
-            "type": "integer",
-            "default": 8
-        },
         "password": {
             "title": "Password",
             "description": "The password of the instance. (Supports EL and secrets)",
@@ -29,7 +23,7 @@
         },
         "timeout": {
             "title": "Timeout (in milliseconds)",
-            "description": "The timeout parameter specifies the connection timeout and the read/write timeout.",
+            "description": "The command timeout in milliseconds. If a Redis command takes longer than this, it will fail.",
             "type": "integer",
             "default": 2000,
             "minimum": 0

--- a/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceIntegrationTest.java
+++ b/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceIntegrationTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.cache.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.el.TemplateEngine;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
+import io.gravitee.resource.api.AbstractConfigurableResource;
+import io.gravitee.resource.cache.api.Cache;
+import io.gravitee.resource.cache.api.Element;
+import io.gravitee.resource.cache.redis.configuration.RedisCacheResourceConfiguration;
+import io.vertx.core.Vertx;
+import java.lang.reflect.Field;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * End-to-end integration test for {@link RedisCacheResource}. Exercises the full lifecycle
+ * (doStart/doStop, shared client registry, password-protected auth) against a real Redis
+ * instance started by Testcontainers.
+ */
+@Testcontainers
+class RedisCacheResourceIntegrationTest {
+
+    private static final String REDIS_PASSWORD = "s3cret";
+
+    @Container
+    static final GenericContainer<?> REDIS = new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+        .withExposedPorts(6379)
+        .withCommand("redis-server", "--requirepass", REDIS_PASSWORD);
+
+    private static Vertx vertx;
+
+    @BeforeAll
+    static void init() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        vertx.close();
+    }
+
+    @AfterEach
+    void assertRegistryDrained() {
+        assertThat(SharedRedisClientRegistry.INSTANCE.registrySize()).as("Registry should be empty after each test").isZero();
+    }
+
+    @Test
+    void should_authenticate_with_password_and_roundtrip() throws Exception {
+        RedisCacheResource resource = underTest(configWithPassword(REDIS_PASSWORD));
+        resource.start();
+
+        Cache cache = resource.getCache(emptyCtx());
+        cache.put(element("k1", "v1"));
+        Element retrieved = cache.get("k1");
+
+        assertThat(retrieved).isNotNull();
+        assertThat(retrieved.value()).isEqualTo("v1");
+
+        resource.stop();
+    }
+
+    @Test
+    void should_return_null_when_password_is_wrong() throws Exception {
+        RedisCacheResource resource = underTest(configWithPassword("wrong-password"));
+        resource.start();
+
+        // Auth fails -> sync API swallows error and returns null (see RedisDelegate.awaitBlocking)
+        Cache cache = resource.getCache(emptyCtx());
+        assertThat(cache.get("anything")).isNull();
+
+        resource.stop();
+    }
+
+    @Test
+    void should_share_client_between_resources_with_same_config() throws Exception {
+        RedisCacheResource resource1 = underTest(configWithPassword(REDIS_PASSWORD));
+        RedisCacheResource resource2 = underTest(configWithPassword(REDIS_PASSWORD));
+
+        resource1.start();
+        resource2.start();
+
+        assertThat(SharedRedisClientRegistry.INSTANCE.registrySize()).as("Both resources should share one client").isEqualTo(1);
+
+        // Put via resource1, read via resource2 — proves they share the same backend
+        resource1.getCache(emptyCtx()).put(element("shared-key", "shared-value"));
+        Element retrieved = resource2.getCache(emptyCtx()).get("shared-key");
+
+        assertThat(retrieved).isNotNull();
+        assertThat(retrieved.value()).isEqualTo("shared-value");
+
+        // Stop one -> client still alive (refcount=1)
+        resource1.stop();
+        assertThat(SharedRedisClientRegistry.INSTANCE.registrySize()).isEqualTo(1);
+
+        // resource2 still works
+        assertThat(resource2.getCache(emptyCtx()).get("shared-key")).isNotNull();
+
+        // Stop the last holder -> client closed, registry empty
+        resource2.stop();
+    }
+
+    @Test
+    void should_not_leak_registry_refcount_across_start_stop_cycles() throws Exception {
+        int cycles = 5;
+        for (int i = 0; i < cycles; i++) {
+            RedisCacheResource resource = underTest(configWithPassword(REDIS_PASSWORD));
+            resource.start();
+            resource.stop();
+        }
+
+        assertThat(SharedRedisClientRegistry.INSTANCE.registrySize()).isZero();
+    }
+
+    private RedisCacheResourceConfiguration configWithPassword(String password) {
+        RedisCacheResourceConfiguration config = new RedisCacheResourceConfiguration();
+        config.getStandalone().setHost(REDIS.getHost());
+        config.getStandalone().setPort(REDIS.getMappedPort(6379));
+        config.setPassword(password);
+        // Testcontainers Redis is plain TCP — override the SSL default
+        config.setUseSsl(false);
+        return config;
+    }
+
+    private static BaseExecutionContext emptyCtx() {
+        BaseExecutionContext ctx = mock(BaseExecutionContext.class);
+        when(ctx.getAttributes()).thenReturn(Map.of());
+        return ctx;
+    }
+
+    private static Element element(Object key, Object value) {
+        return new Element() {
+            @Override
+            public Object key() {
+                return key;
+            }
+
+            @Override
+            public Object value() {
+                return value;
+            }
+        };
+    }
+
+    private RedisCacheResource underTest(RedisCacheResourceConfiguration config) throws Exception {
+        RedisCacheResource resource = new RedisCacheResource();
+        Field configurationField = AbstractConfigurableResource.class.getDeclaredField("configuration");
+        configurationField.setAccessible(true);
+        configurationField.set(resource, config);
+        resource.setDeploymentContext(new TestDeploymentContext(TemplateEngine.templateEngine()));
+        resource.setApplicationContext(mockApplicationContext());
+        return resource;
+    }
+
+    private ApplicationContext mockApplicationContext() {
+        ApplicationContext ctx = mock(ApplicationContext.class);
+        when(ctx.getBean(Vertx.class)).thenReturn(vertx);
+        Environment env = mock(Environment.class);
+        when(env.getProperty("redis.configurations.default.maxPoolSize", Integer.class, 6)).thenReturn(6);
+        when(env.getProperty("redis.configurations.default.poolCleanerInterval", Integer.class, 30000)).thenReturn(30000);
+        when(env.getProperty("redis.configurations.default.poolRecycleTimeout", Integer.class, 180000)).thenReturn(180000);
+        when(env.getProperty("redis.configurations.default.connectTimeout", Integer.class, 2000)).thenReturn(2000);
+        when(ctx.getBean(Environment.class)).thenReturn(env);
+        return ctx;
+    }
+}

--- a/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceTest.java
+++ b/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceTest.java
@@ -16,22 +16,27 @@
 package io.gravitee.resource.cache.redis;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.el.spel.context.SecuredResolver;
 import io.gravitee.resource.api.AbstractConfigurableResource;
+import io.gravitee.resource.cache.redis.configuration.HostAndPort;
 import io.gravitee.resource.cache.redis.configuration.RedisCacheResourceConfiguration;
 import io.gravitee.secrets.api.el.DelegatingEvaluatedSecretsMethods;
 import io.gravitee.secrets.api.el.EvaluatedSecretsMethods;
 import io.gravitee.secrets.api.el.FieldKind;
 import io.gravitee.secrets.api.el.SecretFieldAccessControl;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.Vertx;
+import io.vertx.redis.client.Redis;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.*;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
 
 /**
  * @author Benoit BORDIGONI (benoit.bordigoni at graviteesource.com)
@@ -41,30 +46,37 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 class RedisCacheResourceTest {
 
     private static TemplateEngine templateEngine;
+    private static Vertx vertx;
     private List<SecretFieldAccessControl> recordedSecretFieldAccessControls = new ArrayList<>();
 
     @BeforeAll
     static void init() {
         SecuredResolver.initialize(null);
         templateEngine = TemplateEngine.templateEngine();
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        vertx.close();
     }
 
     @BeforeEach
     void before() {
         EvaluatedSecretsMethods delegate = new EvaluatedSecretsMethods() {
             @Override
-            public String fromGrant(String secretValue, SecretFieldAccessControl secretFieldAccessControl) {
+            public Single<String> fromGrant(String secretValue, SecretFieldAccessControl secretFieldAccessControl) {
                 recordedSecretFieldAccessControls.add(secretFieldAccessControl);
-                return secretValue;
+                return Single.just(secretValue);
             }
 
             @Override
-            public String fromGrant(String contextId, String secretKey, SecretFieldAccessControl secretFieldAccessControl) {
+            public Single<String> fromGrant(String contextId, String secretKey, SecretFieldAccessControl secretFieldAccessControl) {
                 return fromGrant(contextId, secretFieldAccessControl);
             }
 
             @Override
-            public String fromEL(String contextId, String uriOrName, SecretFieldAccessControl secretFieldAccessControl) {
+            public Single<String> fromEL(String contextId, String uriOrName, SecretFieldAccessControl secretFieldAccessControl) {
                 return fromGrant(contextId, secretFieldAccessControl);
             }
         };
@@ -107,6 +119,8 @@ class RedisCacheResourceTest {
             new SecretFieldAccessControl(true, FieldKind.PASSWORD, "password"),
             new SecretFieldAccessControl(true, FieldKind.PASSWORD, "sentinel.password")
         );
+
+        redisCacheResource.stop();
     }
 
     @Test
@@ -116,60 +130,155 @@ class RedisCacheResourceTest {
         RedisCacheResource redisCacheResource = underTest(redisCacheResourceConfiguration);
         redisCacheResource.start();
         assertThat(recordedSecretFieldAccessControls).containsExactlyInAnyOrder(new SecretFieldAccessControl(false, null, null));
+        redisCacheResource.stop();
     }
 
     @Test
-    void should_destroy_connection_factory_on_stop() throws Exception {
-        AtomicBoolean destroyCalled = new AtomicBoolean(false);
-
+    void should_release_shared_client_on_stop() throws Exception {
         RedisCacheResourceConfiguration config = new RedisCacheResourceConfiguration();
-        RedisCacheResource resource = new RedisCacheResource() {
-            @Override
-            public RedisConnectionFactory getConnectionFactory() {
-                // Call super to go through the real config-based path, then swap the field
-                // with a trackable factory that records destroy() calls
-                super.getConnectionFactory();
-                LettuceConnectionFactory trackable = new LettuceConnectionFactory() {
-                    @Override
-                    public void destroy() {
-                        destroyCalled.set(true);
-                    }
-                };
-                try {
-                    Field f = RedisCacheResource.class.getDeclaredField("lettuceConnectionFactory");
-                    f.setAccessible(true);
-                    f.set(this, trackable);
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-                return trackable;
-            }
-        };
-        Field configurationField = AbstractConfigurableResource.class.getDeclaredField("configuration");
-        configurationField.setAccessible(true);
-        configurationField.set(resource, config);
-        resource.setDeploymentContext(new TestDeploymentContext(templateEngine));
+        RedisCacheResource resource = underTest(config);
 
         resource.start();
 
-        // Verify factory field is populated after start
-        Field factoryField = RedisCacheResource.class.getDeclaredField("lettuceConnectionFactory");
-        factoryField.setAccessible(true);
-        assertThat(factoryField.get(resource)).isNotNull();
+        // Verify redisClient field is populated after start
+        Field clientField = RedisCacheResource.class.getDeclaredField("redisClient");
+        clientField.setAccessible(true);
+        assertThat(clientField.get(resource)).isNotNull();
 
-        // Verify redisCacheManager is populated after start
-        Field cacheManagerField = RedisCacheResource.class.getDeclaredField("redisCacheManager");
-        cacheManagerField.setAccessible(true);
-        assertThat(cacheManagerField.get(resource)).isNotNull();
+        // Verify registryKey is set
+        Field keyField = RedisCacheResource.class.getDeclaredField("registryKey");
+        keyField.setAccessible(true);
+        assertThat(keyField.get(resource)).isNotNull();
+
+        // Registry should have 1 entry
+        assertThat(SharedRedisClientRegistry.INSTANCE.registrySize()).isEqualTo(1);
 
         resource.stop();
 
-        // The critical assertion: destroy() must be called to release Netty threads
-        assertThat(destroyCalled.get()).as("destroy() must be called on the connection factory").isTrue();
-
         // Fields should be cleaned up after stop
-        assertThat(factoryField.get(resource)).isNull();
-        assertThat(cacheManagerField.get(resource)).isNull();
+        assertThat(clientField.get(resource)).isNull();
+        assertThat(keyField.get(resource)).isNull();
+
+        // Registry should be empty (last reference released)
+        assertThat(SharedRedisClientRegistry.INSTANCE.registrySize()).isZero();
+    }
+
+    @Test
+    void should_share_client_between_two_resources_with_same_config() throws Exception {
+        RedisCacheResourceConfiguration config1 = new RedisCacheResourceConfiguration();
+        RedisCacheResourceConfiguration config2 = new RedisCacheResourceConfiguration();
+
+        RedisCacheResource resource1 = underTest(config1);
+        RedisCacheResource resource2 = underTest(config2);
+
+        resource1.start();
+        resource2.start();
+
+        // Both should share the same Redis client instance
+        Field clientField = RedisCacheResource.class.getDeclaredField("redisClient");
+        clientField.setAccessible(true);
+        assertThat(clientField.get(resource1)).isSameAs(clientField.get(resource2));
+
+        // Registry should have 1 entry (shared)
+        assertThat(SharedRedisClientRegistry.INSTANCE.registrySize()).isEqualTo(1);
+
+        // Stop first resource — client should stay (still referenced by resource2)
+        resource1.stop();
+        assertThat(SharedRedisClientRegistry.INSTANCE.registrySize()).isEqualTo(1);
+
+        // Stop second resource — client should be closed
+        resource2.stop();
+        assertThat(SharedRedisClientRegistry.INSTANCE.registrySize()).isZero();
+    }
+
+    @Test
+    void should_build_connection_string_standalone() {
+        assertThat(RedisCacheResource.buildConnectionString("localhost", 6379, false)).isEqualTo("redis://localhost:6379");
+    }
+
+    @Test
+    void should_build_connection_string_with_ssl() {
+        assertThat(RedisCacheResource.buildConnectionString("redis.example.com", 6380, true)).isEqualTo("rediss://redis.example.com:6380");
+    }
+
+    @Test
+    void should_start_with_ssl_enabled() throws Exception {
+        RedisCacheResourceConfiguration config = new RedisCacheResourceConfiguration();
+        config.setUseSsl(true);
+        config.getStandalone().setHost("redis.example.com");
+        config.getStandalone().setPort(6380);
+
+        RedisCacheResource resource = underTest(config);
+        resource.start();
+
+        Field keyField = RedisCacheResource.class.getDeclaredField("registryKey");
+        keyField.setAccessible(true);
+        String key = (String) keyField.get(resource);
+        assertThat(key).contains("ssl=true").contains("redis.example.com").contains("6380");
+
+        resource.stop();
+        assertThat(SharedRedisClientRegistry.INSTANCE.registrySize()).isZero();
+    }
+
+    @Test
+    void should_start_with_sentinel_config() throws Exception {
+        RedisCacheResourceConfiguration config = new RedisCacheResourceConfiguration();
+        config.getSentinel().setEnabled(true);
+        config.getSentinel().setMasterId("mymaster");
+        config.getSentinel().setPassword("sentinel-pass");
+        config.getSentinel().getNodes().add(hostAndPort("sentinel1", 26379));
+        config.getSentinel().getNodes().add(hostAndPort("sentinel2", 26380));
+        config.setPassword("redis-pass");
+        config.setUseSsl(false);
+
+        RedisCacheResource resource = underTest(config);
+        resource.start();
+
+        Field keyField = RedisCacheResource.class.getDeclaredField("registryKey");
+        keyField.setAccessible(true);
+        String key = (String) keyField.get(resource);
+        assertThat(key)
+            .startsWith("sentinel|")
+            .contains("mymaster")
+            .contains("sentinel1:26379")
+            .contains("sentinel2:26380")
+            .contains("sentinel-pass")
+            .contains("redis-pass");
+
+        resource.stop();
+        assertThat(SharedRedisClientRegistry.INSTANCE.registrySize()).isZero();
+    }
+
+    @Test
+    void should_not_share_clients_with_different_ssl_settings() throws Exception {
+        RedisCacheResourceConfiguration config1 = new RedisCacheResourceConfiguration();
+        config1.setUseSsl(false);
+
+        RedisCacheResourceConfiguration config2 = new RedisCacheResourceConfiguration();
+        config2.setUseSsl(true);
+
+        RedisCacheResource resource1 = underTest(config1);
+        RedisCacheResource resource2 = underTest(config2);
+
+        resource1.start();
+        resource2.start();
+
+        // Different SSL settings = different clients
+        Field clientField = RedisCacheResource.class.getDeclaredField("redisClient");
+        clientField.setAccessible(true);
+        assertThat(clientField.get(resource1)).isNotSameAs(clientField.get(resource2));
+        assertThat(SharedRedisClientRegistry.INSTANCE.registrySize()).isEqualTo(2);
+
+        resource1.stop();
+        resource2.stop();
+        assertThat(SharedRedisClientRegistry.INSTANCE.registrySize()).isZero();
+    }
+
+    private static HostAndPort hostAndPort(String host, int port) {
+        HostAndPort hp = new HostAndPort();
+        hp.setHost(host);
+        hp.setPort(port);
+        return hp;
     }
 
     private static String asSecretEL(String password) {
@@ -182,6 +291,19 @@ class RedisCacheResourceTest {
         configurationField.setAccessible(true);
         configurationField.set(redisCacheResource, config);
         redisCacheResource.setDeploymentContext(new TestDeploymentContext(templateEngine));
+        redisCacheResource.setApplicationContext(mockApplicationContext());
         return redisCacheResource;
+    }
+
+    private ApplicationContext mockApplicationContext() {
+        ApplicationContext ctx = mock(ApplicationContext.class);
+        when(ctx.getBean(Vertx.class)).thenReturn(vertx);
+        Environment env = mock(Environment.class);
+        when(env.getProperty("redis.configurations.default.maxPoolSize", Integer.class, 6)).thenReturn(6);
+        when(env.getProperty("redis.configurations.default.poolCleanerInterval", Integer.class, 30000)).thenReturn(30000);
+        when(env.getProperty("redis.configurations.default.poolRecycleTimeout", Integer.class, 180000)).thenReturn(180000);
+        when(env.getProperty("redis.configurations.default.connectTimeout", Integer.class, 2000)).thenReturn(2000);
+        when(ctx.getBean(Environment.class)).thenReturn(env);
+        return ctx;
     }
 }

--- a/src/test/java/io/gravitee/resource/cache/redis/RedisDelegateIntegrationTest.java
+++ b/src/test/java/io/gravitee/resource/cache/redis/RedisDelegateIntegrationTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.cache.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.gravitee.resource.cache.api.Element;
+import io.vertx.core.Vertx;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisAPI;
+import io.vertx.redis.client.RedisOptions;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class RedisDelegateIntegrationTest {
+
+    @Container
+    static final GenericContainer<?> REDIS = new GenericContainer<>(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379);
+
+    private static Vertx vertx;
+    private static Redis redisClient;
+    private static RedisAPI redisAPI;
+
+    private RedisDelegate delegate;
+
+    @BeforeAll
+    static void bootstrapClient() {
+        vertx = Vertx.vertx();
+        RedisOptions options = new RedisOptions().setConnectionString("redis://" + REDIS.getHost() + ":" + REDIS.getMappedPort(6379));
+        redisClient = Redis.createClient(vertx, options);
+        redisAPI = RedisAPI.api(redisClient);
+    }
+
+    @AfterAll
+    static void shutdownClient() {
+        redisClient.close();
+        vertx.close();
+    }
+
+    @BeforeEach
+    void setUp() {
+        delegate = new RedisDelegate(redisAPI, "gravitee:", Map.of(), 60, false, 2000L);
+    }
+
+    @AfterEach
+    void flush() {
+        redisAPI.flushall(java.util.List.of()).toCompletionStage().toCompletableFuture().join();
+    }
+
+    @Test
+    void should_put_and_get_element() {
+        delegate.put(element("k1", "v1", 0));
+
+        Element retrieved = delegate.get("k1");
+
+        assertThat(retrieved).isNotNull();
+        assertThat(retrieved.value()).isEqualTo("v1");
+    }
+
+    @Test
+    void should_return_null_when_key_missing() {
+        assertThat(delegate.get("missing")).isNull();
+    }
+
+    @Test
+    void should_evict_element() {
+        delegate.put(element("k2", "v2", 0));
+        delegate.evict("k2");
+
+        assertThat(delegate.get("k2")).isNull();
+    }
+
+    @Test
+    void should_honor_element_ttl_when_lower_than_default() {
+        delegate.put(element("short", "v", 1));
+
+        assertThat(delegate.get("short")).isNotNull();
+
+        await()
+            .atMost(Duration.ofSeconds(3))
+            .pollInterval(Duration.ofMillis(200))
+            .untilAsserted(() -> assertThat(delegate.get("short")).isNull());
+    }
+
+    @Test
+    void should_use_default_ttl_when_element_ttl_higher() throws Exception {
+        // default TTL = 60s (from constructor). Element TTL = 120s, so 60s wins.
+        delegate.put(element("kttl", "v", 120));
+
+        // Inspect TTL in Redis directly
+        long ttl = redisAPI.ttl("gravitee:kttl").toCompletionStage().toCompletableFuture().get(2, TimeUnit.SECONDS).toLong();
+
+        assertThat(ttl).isBetween(1L, 60L);
+    }
+
+    @Test
+    void should_clear_all_keys_for_cache_name() {
+        delegate.put(element("a", "1", 0));
+        delegate.put(element("b", "2", 0));
+        delegate.put(element("c", "3", 0));
+
+        delegate.clear();
+
+        assertThat(delegate.get("a")).isNull();
+        assertThat(delegate.get("b")).isNull();
+        assertThat(delegate.get("c")).isNull();
+    }
+
+    private static Element element(Object key, Object value, int ttl) {
+        return new Element() {
+            @Override
+            public Object key() {
+                return key;
+            }
+
+            @Override
+            public Object value() {
+                return value;
+            }
+
+            @Override
+            public int timeToLive() {
+                return ttl;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Replace Lettuce + Spring Data Redis with Vert.x `RedisAPI` for all cache operations
- Shared `Redis` client via `SharedRedisClientRegistry` with reference counting (same pattern as hotfix PR #72, now holding Vert.x client instead of `LettuceConnectionFactory`)
- Native async `getAsync`/`putAsync`/`evictAsync`/`clearAsync` using Vert.x `Future`
- Blocking sync methods kept for backward compat, delegate to async via `CompletableFuture.join()`
- Pool config from `gravitee.yml` (`resources.cacheRedis.maxPoolSize/poolCleanerInterval/poolRecycleTimeout`) via `Environment.getProperty()`
- Same Redis key/value format (plain UTF-8 strings) — rolling upgrade safe
- Plugin assembly: ~250KB (was ~12MB with Lettuce/Spring/Netty/Reactor)

**Breaking change**: `getNativeCache()` returns `RedisAPI` instead of `RedisCacheWriter`. All Lettuce/Spring Data Redis/commons-pool2 dependencies removed.

Depends on `gravitee-resource-cache-provider-api` 2.1.0 (async `Future`-based cache methods).

## Test plan
- [x] `mvn clean test` — 5/5 tests pass
- [x] Assembly contains only `vertx-redis-client` (no Lettuce/Spring Data Redis JARs)
- [ ] Integration test: build plugin, deploy to gateway, verify cache GET/SET via `redis-cli monitor`
- [ ] Verify same key format as previous version for upgrade safety
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.0-feat-shared-connection-factory-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache-redis/4.1.0-feat-shared-connection-factory-SNAPSHOT/gravitee-resource-cache-redis-4.1.0-feat-shared-connection-factory-SNAPSHOT.zip)
  <!-- Version placeholder end -->
