### PR TITLE
feat(redis-cache): move pool/timeout config from gravitee.yml to per-API resource form

### DIFF
--- a/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
@@ -36,7 +36,6 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.core.env.Environment;
 
 /**
  * @author Guillaume CUSNIEUX (guillaume.cusnieux at graviteesource.com)
@@ -76,7 +75,7 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
 
         registryKey = SharedRedisClientRegistry.buildKey(configuration);
 
-        redisClient = SharedRedisClientRegistry.INSTANCE.acquire(registryKey, () -> {
+        redisClient = SharedRedisClientRegistry.INSTANCE.acquire(registryKey, configuration, () -> {
             RedisOptions options = buildRedisOptions();
             return Redis.createClient(vertx, options);
         });
@@ -174,20 +173,12 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
             options.getNetClientOptions().setHostnameVerificationAlgorithm("");
         }
 
-        // Pool config from gravitee.yml
-        Environment env = applicationContext.getBean(Environment.class);
-        int maxPoolSize = env.getProperty("redis.configurations.default.maxPoolSize", Integer.class, 6);
-        int cleanerInterval = env.getProperty("redis.configurations.default.poolCleanerInterval", Integer.class, 30000);
-        int recycleTimeout = env.getProperty("redis.configurations.default.poolRecycleTimeout", Integer.class, 180000);
-
-        options.setMaxPoolSize(maxPoolSize);
-        options.setPoolCleanerInterval(cleanerInterval);
-        options.setPoolRecycleTimeout(recycleTimeout);
-        options.setMaxWaitingHandlers(1024);
-
-        // Connection timeout from gravitee.yml
-        int connectTimeout = env.getProperty("redis.configurations.default.connectTimeout", Integer.class, 2000);
-        options.getNetClientOptions().setConnectTimeout(connectTimeout);
+        options.setMaxPoolSize(configuration.getMaxPoolSize());
+        options.setMaxPoolWaiting(configuration.getMaxPoolWaiting());
+        options.setPoolCleanerInterval(configuration.getPoolCleanerInterval());
+        options.setPoolRecycleTimeout(configuration.getPoolRecycleTimeout());
+        options.setMaxWaitingHandlers(configuration.getMaxWaitingHandlers());
+        options.getNetClientOptions().setConnectTimeout(configuration.getConnectTimeout());
 
         return options;
     }

--- a/src/main/java/io/gravitee/resource/cache/redis/SharedRedisClientRegistry.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/SharedRedisClientRegistry.java
@@ -44,17 +44,19 @@ class SharedRedisClientRegistry {
 
     /**
      * Acquire a shared Redis client for the given key. If none exists, creates one using the supplier.
+     * Logs a warning if the new consumer's pool/timeout config differs from the first acquire.
      */
-    Redis acquire(String key, Supplier<Redis> clientSupplier) {
+    Redis acquire(String key, RedisCacheResourceConfiguration config, Supplier<Redis> clientSupplier) {
         RefCountedClient ref = clients.compute(key, (k, existing) -> {
             if (existing != null) {
                 existing.refCount.incrementAndGet();
+                warnOnPoolMismatch(config, existing.originalConfig, existing.refCount.get());
                 log.debug("Reusing shared Redis client, refCount={}, registrySize={}", existing.refCount.get(), clients.size());
                 return existing;
             }
             Redis client = clientSupplier.get();
             log.info("Created new shared Redis client, registrySize={}", clients.size() + 1);
-            return new RefCountedClient(client);
+            return new RefCountedClient(client, config);
         });
         return ref.client;
     }
@@ -118,6 +120,52 @@ class SharedRedisClientRegistry {
         return sb.toString();
     }
 
+    private static void warnOnPoolMismatch(
+        RedisCacheResourceConfiguration requested,
+        RedisCacheResourceConfiguration original,
+        int refCount
+    ) {
+        var mismatches = new ArrayList<String>();
+        if (requested.getMaxPoolSize() != original.getMaxPoolSize()) {
+            mismatches.add("maxPoolSize: requested=" + requested.getMaxPoolSize() + " vs active=" + original.getMaxPoolSize());
+        }
+        if (requested.getMaxPoolWaiting() != original.getMaxPoolWaiting()) {
+            mismatches.add("maxPoolWaiting: requested=" + requested.getMaxPoolWaiting() + " vs active=" + original.getMaxPoolWaiting());
+        }
+        if (requested.getPoolCleanerInterval() != original.getPoolCleanerInterval()) {
+            mismatches.add(
+                "poolCleanerInterval: requested=" + requested.getPoolCleanerInterval() + " vs active=" + original.getPoolCleanerInterval()
+            );
+        }
+        if (requested.getPoolRecycleTimeout() != original.getPoolRecycleTimeout()) {
+            mismatches.add(
+                "poolRecycleTimeout: requested=" + requested.getPoolRecycleTimeout() + " vs active=" + original.getPoolRecycleTimeout()
+            );
+        }
+        if (requested.getMaxWaitingHandlers() != original.getMaxWaitingHandlers()) {
+            mismatches.add(
+                "maxWaitingHandlers: requested=" + requested.getMaxWaitingHandlers() + " vs active=" + original.getMaxWaitingHandlers()
+            );
+        }
+        if (requested.getConnectTimeout() != original.getConnectTimeout()) {
+            mismatches.add("connectTimeout: requested=" + requested.getConnectTimeout() + " vs active=" + original.getConnectTimeout());
+        }
+        if (!mismatches.isEmpty()) {
+            String connection = original.getSentinel().isEnabled() || original.isSentinelMode()
+                ? "sentinel:" + original.getSentinel().getMasterId()
+                : original.getStandalone().getHost() + ":" + original.getStandalone().getPort();
+            log.warn(
+                "Shared Redis client for {} has pool/timeout settings mismatch. " +
+                    "First-acquire wins, these values from the new consumer are ignored: [{}]. " +
+                    "To align, ensure all resources pointing to this Redis use the same pool configuration. " +
+                    "Current shared client has {} active references.",
+                connection,
+                String.join(", ", mismatches),
+                refCount
+            );
+        }
+    }
+
     // Visible for testing
     int registrySize() {
         return clients.size();
@@ -127,10 +175,12 @@ class SharedRedisClientRegistry {
 
         final Redis client;
         final AtomicInteger refCount;
+        final RedisCacheResourceConfiguration originalConfig;
 
-        RefCountedClient(Redis client) {
+        RefCountedClient(Redis client, RedisCacheResourceConfiguration originalConfig) {
             this.client = client;
             this.refCount = new AtomicInteger(1);
+            this.originalConfig = originalConfig;
         }
     }
 }

--- a/src/main/java/io/gravitee/resource/cache/redis/configuration/RedisCacheResourceConfiguration.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/configuration/RedisCacheResourceConfiguration.java
@@ -41,6 +41,14 @@ public class RedisCacheResourceConfiguration implements ResourceConfiguration {
     private boolean releaseCache;
     private boolean useSsl = true;
 
+    // Pool and timeout settings (per-API; shared clients use first-acquire-wins, mismatches logged)
+    private int maxPoolSize = 6;
+    private int maxPoolWaiting = 1024;
+    private int poolCleanerInterval = 30000;
+    private int poolRecycleTimeout = 180000;
+    private int maxWaitingHandlers = 1024;
+    private int connectTimeout = 2000;
+
     @Deprecated
     private boolean sentinelMode = false;
 

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -12,7 +12,10 @@
             "title": "Password",
             "description": "The password of the instance. (Supports EL and secrets)",
             "type": "string",
-            "writeOnly": true
+            "writeOnly": true,
+            "gioConfig": {
+                "el": true
+            }
         },
         "timeToLiveSeconds": {
             "title": "Time to live (in seconds)",
@@ -47,13 +50,19 @@
                             "title": "Host",
                             "description": "The host of the instance. (Supports EL)",
                             "type": "string",
-                            "default": "localhost"
+                            "default": "localhost",
+                            "gioConfig": {
+                                "el": true
+                            }
                         },
                         "port": {
                             "title": "Port",
-                            "description": "The port of the instance.",
+                            "description": "The port of the instance. (Supports EL)",
                             "type": "integer",
-                            "default": 6379
+                            "default": 6379,
+                            "gioConfig": {
+                                "el": true
+                            }
                         }
                     },
                     "required": ["host", "port"]
@@ -78,6 +87,60 @@
                 }
             }
         },
+        "maxPoolSize": {
+            "title": "Max pool size",
+            "description": "Maximum number of connections in the pool. (Supports EL)",
+            "type": "integer",
+            "default": 6,
+            "gioConfig": {
+                "el": true
+            }
+        },
+        "maxPoolWaiting": {
+            "title": "Max pool waiting",
+            "description": "Maximum number of requests waiting for a connection from the pool. (Supports EL)",
+            "type": "integer",
+            "default": 1024,
+            "gioConfig": {
+                "el": true
+            }
+        },
+        "poolCleanerInterval": {
+            "title": "Pool cleaner interval (ms)",
+            "description": "Interval in milliseconds between pool cleaner runs. (Supports EL)",
+            "type": "integer",
+            "default": 30000,
+            "gioConfig": {
+                "el": true
+            }
+        },
+        "poolRecycleTimeout": {
+            "title": "Pool recycle timeout (ms)",
+            "description": "Timeout in milliseconds for recycling idle connections. (Supports EL)",
+            "type": "integer",
+            "default": 180000,
+            "gioConfig": {
+                "el": true
+            }
+        },
+        "maxWaitingHandlers": {
+            "title": "Max waiting handlers",
+            "description": "Maximum number of waiting handlers for the Redis client. (Supports EL)",
+            "type": "integer",
+            "default": 1024,
+            "gioConfig": {
+                "el": true
+            }
+        },
+        "connectTimeout": {
+            "title": "Connect timeout (ms)",
+            "description": "Maximum time in milliseconds to establish a connection. (Supports EL)",
+            "type": "integer",
+            "default": 2000,
+            "gioConfig": {
+                "el": true
+            }
+        },
         "sentinel": {
             "type": "object",
             "oneOf": [
@@ -91,13 +154,19 @@
                             "title": "Master",
                             "description": "The sentinel master id. (Supports EL)",
                             "type": "string",
-                            "default": "sentinel-master"
+                            "default": "sentinel-master",
+                            "gioConfig": {
+                                "el": true
+                            }
                         },
                         "password": {
                             "title": "Sentinel password",
                             "description": "The sentinel password. (Supports EL and secrets)",
                             "type": "string",
-                            "writeOnly": true
+                            "writeOnly": true,
+                            "gioConfig": {
+                                "el": true
+                            }
                         },
                         "nodes": {
                             "type": "array",
@@ -108,13 +177,21 @@
                                 "properties": {
                                     "host": {
                                         "title": "The host of node",
+                                        "description": "(Supports EL)",
                                         "type": "string",
-                                        "default": "localhost"
+                                        "default": "localhost",
+                                        "gioConfig": {
+                                            "el": true
+                                        }
                                     },
                                     "port": {
                                         "title": "The port of node",
+                                        "description": "(Supports EL)",
                                         "type": "integer",
-                                        "default": 26379
+                                        "default": 26379,
+                                        "gioConfig": {
+                                            "el": true
+                                        }
                                     }
                                 },
                                 "required": ["host", "port"]

--- a/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceIntegrationTest.java
+++ b/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceIntegrationTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
-import org.springframework.core.env.Environment;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -181,12 +180,6 @@ class RedisCacheResourceIntegrationTest {
     private ApplicationContext mockApplicationContext() {
         ApplicationContext ctx = mock(ApplicationContext.class);
         when(ctx.getBean(Vertx.class)).thenReturn(vertx);
-        Environment env = mock(Environment.class);
-        when(env.getProperty("redis.configurations.default.maxPoolSize", Integer.class, 6)).thenReturn(6);
-        when(env.getProperty("redis.configurations.default.poolCleanerInterval", Integer.class, 30000)).thenReturn(30000);
-        when(env.getProperty("redis.configurations.default.poolRecycleTimeout", Integer.class, 180000)).thenReturn(180000);
-        when(env.getProperty("redis.configurations.default.connectTimeout", Integer.class, 2000)).thenReturn(2000);
-        when(ctx.getBean(Environment.class)).thenReturn(env);
         return ctx;
     }
 }

--- a/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceTest.java
+++ b/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceTest.java
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.*;
 import org.springframework.context.ApplicationContext;
-import org.springframework.core.env.Environment;
 
 /**
  * @author Benoit BORDIGONI (benoit.bordigoni at graviteesource.com)
@@ -298,12 +297,6 @@ class RedisCacheResourceTest {
     private ApplicationContext mockApplicationContext() {
         ApplicationContext ctx = mock(ApplicationContext.class);
         when(ctx.getBean(Vertx.class)).thenReturn(vertx);
-        Environment env = mock(Environment.class);
-        when(env.getProperty("redis.configurations.default.maxPoolSize", Integer.class, 6)).thenReturn(6);
-        when(env.getProperty("redis.configurations.default.poolCleanerInterval", Integer.class, 30000)).thenReturn(30000);
-        when(env.getProperty("redis.configurations.default.poolRecycleTimeout", Integer.class, 180000)).thenReturn(180000);
-        when(env.getProperty("redis.configurations.default.connectTimeout", Integer.class, 2000)).thenReturn(2000);
-        when(ctx.getBean(Environment.class)).thenReturn(env);
         return ctx;
     }
 }


### PR DESCRIPTION
## Summary
- Pool and timeout settings (`maxPoolSize`, `maxPoolWaiting`, `poolCleanerInterval`, `poolRecycleTimeout`, `maxWaitingHandlers`, `connectTimeout`) are now per-API in the resource form instead of globally in `gravitee.yml`.
- `SharedRedisClientRegistry` logs a WARN with connection identity, mismatched values, active ref count, and caller stack trace when a shared client is reused with different pool/timeout settings. First-acquire wins.
- Backward compatible: old API configs without pool fields use defaults matching the previous `gravitee.yml` defaults.
- No new dependencies. Schema fields inlined (no `$ref` / no maven plugin dependency).

## Test plan
- [x] `RedisCacheResourceTest` — 10/10 pass
- [ ] `RedisCacheResourceIntegrationTest` — testcontainers (shared client, start/stop cycles)
- [ ] Manual: deploy 2 APIs with same Redis but different `maxPoolSize`, verify WARN in gateway logs
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.2.0-wba-pool-config-per-api-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache-redis/4.2.0-wba-pool-config-per-api-SNAPSHOT/gravitee-resource-cache-redis-4.2.0-wba-pool-config-per-api-SNAPSHOT.zip)
  <!-- Version placeholder end -->
