### PR TITLE
fix(redis-cache): isolate Redis I/O on dedicated Vertx to prevent event-loop deadlock

### DIFF
--- a/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
@@ -71,13 +71,11 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
 
         configuration = new RedisCacheResourceConfigurationEvaluator(configuration()).evalNow(deploymentContext);
 
-        Vertx vertx = applicationContext.getBean(Vertx.class);
-
         registryKey = SharedRedisClientRegistry.buildKey(configuration);
 
-        redisClient = SharedRedisClientRegistry.INSTANCE.acquire(registryKey, configuration, () -> {
+        redisClient = SharedRedisClientRegistry.INSTANCE.acquire(registryKey, configuration, redisVertx -> {
             RedisOptions options = buildRedisOptions();
-            return Redis.createClient(vertx, options);
+            return Redis.createClient(redisVertx, options);
         });
 
         try {

--- a/src/main/java/io/gravitee/resource/cache/redis/SharedRedisClientRegistry.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/SharedRedisClientRegistry.java
@@ -17,6 +17,8 @@ package io.gravitee.resource.cache.redis;
 
 import io.gravitee.resource.cache.redis.configuration.HostAndPort;
 import io.gravitee.resource.cache.redis.configuration.RedisCacheResourceConfiguration;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import io.vertx.redis.client.Redis;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -24,7 +26,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
+import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -41,12 +43,19 @@ class SharedRedisClientRegistry {
     static final SharedRedisClientRegistry INSTANCE = new SharedRedisClientRegistry();
 
     private final ConcurrentHashMap<String, RefCountedClient> clients = new ConcurrentHashMap<>();
+    private volatile Vertx redisVertx;
 
     /**
-     * Acquire a shared Redis client for the given key. If none exists, creates one using the supplier.
-     * Logs a warning if the new consumer's pool/timeout config differs from the first acquire.
+     * Acquire a shared Redis client for the given key. If none exists, creates one using the supplier,
+     * which receives a dedicated {@link Vertx} instance isolated from the gateway's HTTP event loops.
+     * <p>This isolation is required because sync callers of {@link RedisDelegate#get}/{@code put}/etc.
+     * park the caller's event loop in {@code CompletableFuture.join()}. If the Redis client's Netty
+     * event loop is drawn from the same pool as HTTP-serving event loops, concurrent cache traffic
+     * eventually parks the Netty-hosting loop as well — preventing Redis responses from being read
+     * and deadlocking every in-flight {@code cache.get} until {@code commandTimeoutMs}.
+     * <p>Logs a warning if the new consumer's pool/timeout config differs from the first acquire.
      */
-    Redis acquire(String key, RedisCacheResourceConfiguration config, Supplier<Redis> clientSupplier) {
+    Redis acquire(String key, RedisCacheResourceConfiguration config, Function<Vertx, Redis> clientFactory) {
         RefCountedClient ref = clients.compute(key, (k, existing) -> {
             if (existing != null) {
                 existing.refCount.incrementAndGet();
@@ -54,11 +63,38 @@ class SharedRedisClientRegistry {
                 log.debug("Reusing shared Redis client, refCount={}, registrySize={}", existing.refCount.get(), clients.size());
                 return existing;
             }
-            Redis client = clientSupplier.get();
+            Redis client = clientFactory.apply(redisVertx());
             log.info("Created new shared Redis client, registrySize={}", clients.size() + 1);
             return new RefCountedClient(client, config);
         });
         return ref.client;
+    }
+
+    private Vertx redisVertx() {
+        Vertx v = redisVertx;
+        if (v != null) {
+            return v;
+        }
+        synchronized (this) {
+            if (redisVertx == null) {
+                redisVertx = Vertx.vertx(new VertxOptions().setEventLoopPoolSize(2).setWorkerPoolSize(2));
+                Runtime.getRuntime().addShutdownHook(new Thread(this::closeRedisVertxOnShutdown, "redis-cache-vertx-shutdown"));
+                log.info("Started dedicated Vertx for Redis I/O (eventLoopPoolSize=2)");
+            }
+            return redisVertx;
+        }
+    }
+
+    private void closeRedisVertxOnShutdown() {
+        Vertx v = redisVertx;
+        if (v == null) {
+            return;
+        }
+        try {
+            v.close().toCompletionStage().toCompletableFuture().get(5, java.util.concurrent.TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.warn("Error closing dedicated Redis Vertx on JVM shutdown", e);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

- Vert.x Redis client from 4.1.0+ draws its Netty event loops from the gateway's shared `Vertx` pool. Under sync callers that `.join()` on a `cache.get` future (e.g. `gravitee-policy-oauth2` at `Oauth2Policy.java:234`), enough concurrent traffic eventually parks the event loop hosting the Redis socket — the response can never be delivered, deadlocking every in-flight `cache.get` until `commandTimeoutMs`.
- 4.0.4 (Lettuce) was unaffected because Lettuce owns its own Netty loop, isolated from the gateway's event loops.
- Restore that isolation: create a single process-wide `Vertx` inside `SharedRedisClientRegistry` (2 event loops, 2 workers) and use it for every `Redis.createClient`. Gateway HTTP loops can still park in `.join()`; the Redis response arrives on a loop that is never parked.

## Changes

- `SharedRedisClientRegistry#acquire` now takes `Function<Vertx, Redis>` and passes a lazily-initialized dedicated `Vertx` to the factory (one instance shared across every resource in the JVM — *not* per API).
- JVM shutdown hook closes the dedicated `Vertx` (5 s timeout) as a best-effort safety net; the existing refcount still closes the `Redis` client cleanly on graceful shutdown.
- `RedisCacheResource` no longer looks up `Vertx` from `applicationContext` — gets it via the factory parameter instead.

## Repro

v4 API with `oauth2` policy + `cache-redis` resource + generic `oauth2` resource; 8 parallel requests with `Authorization: Bearer …`.

| Version | `Thread blocked` events | HTTP outcome (8 parallel) |
|---|---|---|
| 4.0.4 | 0 | 503 in ~300 ms |
| 4.1.0 unpatched | 1560 | hang 107 s |
| 4.2.0 unpatched | 248 | hang 15 s |
| **4.2.0 + this patch** | **0** | **~10 ms** |

64-parallel stress on the patched build: 0 blocks, all requests complete in < 28 ms.

## Test plan

- [ ] Existing unit tests pass (`RedisCacheResourceTest`: 10/10 ✔︎ locally)
- [ ] Existing integration tests pass in CI (`RedisDelegateIntegrationTest`, `RedisCacheResourceIntegrationTest` — fail locally due to pre-existing pom/Jackson classpath issue unrelated to this change)
- [ ] Manual repro: v2 API + oauth2 policy + cache-redis resource, 8 parallel bearer-token requests, verify no `Thread blocked` events in gateway log
- [ ] Verify `SharedRedisClientRegistry` log line "Started dedicated Vertx for Redis I/O (eventLoopPoolSize=2)" appears **once** per gateway JVM, regardless of how many cache-redis resources are deployed
- [ ] Confirm graceful shutdown closes the shared `Redis` client via the existing refcount path (log line "Closing shared Redis client (last reference released)")

## Notes for reviewer

- A Jira ticket should be linked before merge — I don't have one to reference yet.
- Integration tests cover exactly the refcount and lifecycle surface this patch touches (share-client-by-config-key, no-leak-across-start-stop). Keep.
- Pool sizes are hard-coded (2 event loops + 2 workers). Can be made configurable later if needed; for now mirroring what Lettuce effectively used in 4.0.4.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.2.1-wba-fix-cache-redis-deadlock-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache-redis/4.2.1-wba-fix-cache-redis-deadlock-SNAPSHOT/gravitee-resource-cache-redis-4.2.1-wba-fix-cache-redis-deadlock-SNAPSHOT.zip)
  <!-- Version placeholder end -->
