### PR TITLE
feat(redis-cache)!: require Java 21 and APIM 4.12

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -23,7 +23,8 @@ Current implementation of the cache resource is based on https://redis.io/[Redis
 |===
 | Plugin version | APIM version
 
-| 4.0            | 4.6 to latest
+| 5.0            | 4.12 to latest
+| 4.0            | 4.6 to 4.11
 | 3.0            | DO NOT USE
 | 2.0            | 4.5 to latest
 | 1.5            | 4.0 to 4.4


### PR DESCRIPTION
## Summary
Documents the Java 21 / APIM 4.12 requirement introduced by #76. 

The commit subject uses the `feat!` semantic-release marker + `BREAKING CHANGE` footer so the next release picks up as a major version bump. The previous merge (#76) used `refactor:` which semantic-release treats as no-release — this PR corrects that so CI actually cuts a new alpha.

## Why
- `gravitee-parent` bumped `22.6.0 -> 24.0.2`, which switched the compile/target level from Java 17 to Java 21.
- `gravitee-apim` BOM now pinned to `4.12.0-SNAPSHOT` for the new `VertxRedisClientFactory`-based client sharing.

Consumers running Java 17 gateways or APIM < 4.12 will not be able to load this plugin.

## Test plan
- [ ] CI triggers semantic-release on merge to `alpha` and publishes a new alpha version
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.0-wba-require-java21-apim412-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache-redis/5.0.0-wba-require-java21-apim412-SNAPSHOT/gravitee-resource-cache-redis-5.0.0-wba-require-java21-apim412-SNAPSHOT.zip)
  <!-- Version placeholder end -->
