### PR TITLE
refactor(redis-cache): move pool/timeout config to gravitee.yml

### DIFF
--- a/src/main/java/io/gravitee/resource/cache/redis/RedisCacheGlobalOptions.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/RedisCacheGlobalOptions.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.cache.redis;
+
+import lombok.Getter;
+import org.springframework.core.env.Environment;
+
+/**
+ * Gateway-wide Redis cache client settings, sourced from {@code gravitee.yml}
+ * under the {@code resources.cacheRedis.*} prefix.
+ *
+ * <p>These fields are connection-pool and timeout settings that must be uniform
+ * across every {@code cache-redis} resource targeting the same Redis endpoint,
+ * because a single shared Vert.x {@link io.vertx.redis.client.Redis} client is
+ * used for all of them (see {@link SharedRedisClientRegistry}) and Vert.x does
+ * not support runtime pool resize. Placing them in {@code gravitee.yml} instead
+ * of per-resource JSON means they really are global — there is no UI field that
+ * looks editable but is silently ignored.
+ *
+ * <p>Example {@code gravitee.yml}:
+ * <pre>
+ * resources:
+ *   cacheRedis:
+ *     maxPoolSize: 60
+ *     maxPoolWaiting: 1024
+ *     poolCleanerInterval: 30000
+ *     poolRecycleTimeout: 180000
+ *     maxWaitingHandlers: 1024
+ *     connectTimeout: 2000
+ * </pre>
+ */
+@Getter
+public final class RedisCacheGlobalOptions {
+
+    private static final String PREFIX = "resources.cacheRedis.";
+
+    private final int maxPoolSize;
+    private final int maxPoolWaiting;
+    private final int poolCleanerInterval;
+    private final int poolRecycleTimeout;
+    private final int maxWaitingHandlers;
+    private final int connectTimeout;
+
+    public RedisCacheGlobalOptions(Environment environment) {
+        this.maxPoolSize = environment.getProperty(PREFIX + "maxPoolSize", Integer.class, 6);
+        this.maxPoolWaiting = environment.getProperty(PREFIX + "maxPoolWaiting", Integer.class, 1024);
+        this.poolCleanerInterval = environment.getProperty(PREFIX + "poolCleanerInterval", Integer.class, 30000);
+        this.poolRecycleTimeout = environment.getProperty(PREFIX + "poolRecycleTimeout", Integer.class, 180000);
+        this.maxWaitingHandlers = environment.getProperty(PREFIX + "maxWaitingHandlers", Integer.class, 1024);
+        this.connectTimeout = environment.getProperty(PREFIX + "connectTimeout", Integer.class, 2000);
+    }
+}

--- a/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
@@ -52,6 +52,7 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
     private DeploymentContext deploymentContext;
 
     private RedisCacheResourceConfiguration configuration;
+    private RedisCacheGlobalOptions globalOptions;
     private volatile Redis redisClient;
     private volatile RedisAPI redisAPI;
     private String registryKey;
@@ -70,12 +71,13 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
         log.debug("Create redis cache resource");
 
         configuration = new RedisCacheResourceConfigurationEvaluator(configuration()).evalNow(deploymentContext);
+        globalOptions = new RedisCacheGlobalOptions(applicationContext.getEnvironment());
 
         Vertx vertx = applicationContext.getBean(Vertx.class);
 
         registryKey = SharedRedisClientRegistry.buildKey(configuration);
 
-        redisClient = SharedRedisClientRegistry.INSTANCE.acquire(registryKey, configuration, () -> {
+        redisClient = SharedRedisClientRegistry.INSTANCE.acquire(registryKey, () -> {
             RedisOptions options = buildRedisOptions();
             return Redis.createClient(vertx, options);
         });
@@ -173,12 +175,12 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
             options.getNetClientOptions().setHostnameVerificationAlgorithm("");
         }
 
-        options.setMaxPoolSize(configuration.getMaxPoolSize());
-        options.setMaxPoolWaiting(configuration.getMaxPoolWaiting());
-        options.setPoolCleanerInterval(configuration.getPoolCleanerInterval());
-        options.setPoolRecycleTimeout(configuration.getPoolRecycleTimeout());
-        options.setMaxWaitingHandlers(configuration.getMaxWaitingHandlers());
-        options.getNetClientOptions().setConnectTimeout(configuration.getConnectTimeout());
+        options.setMaxPoolSize(globalOptions.getMaxPoolSize());
+        options.setMaxPoolWaiting(globalOptions.getMaxPoolWaiting());
+        options.setPoolCleanerInterval(globalOptions.getPoolCleanerInterval());
+        options.setPoolRecycleTimeout(globalOptions.getPoolRecycleTimeout());
+        options.setMaxWaitingHandlers(globalOptions.getMaxWaitingHandlers());
+        options.getNetClientOptions().setConnectTimeout(globalOptions.getConnectTimeout());
 
         return options;
     }

--- a/src/main/java/io/gravitee/resource/cache/redis/SharedRedisClientRegistry.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/SharedRedisClientRegistry.java
@@ -34,6 +34,10 @@ import lombok.extern.slf4j.Slf4j;
  *
  * <p>Thread-safe. Keyed by connection parameters (host, port, password, ssl, sentinel config).
  * Uses reference counting: client is created on first acquire, closed when last reference is released.
+ *
+ * <p>Pool and timeout settings are <em>not</em> part of the key — they are gateway-wide
+ * (see {@link RedisCacheGlobalOptions}) so every consumer sharing a connection tuple
+ * contributes the same values by construction.
  */
 @Slf4j
 class SharedRedisClientRegistry {
@@ -44,19 +48,17 @@ class SharedRedisClientRegistry {
 
     /**
      * Acquire a shared Redis client for the given key. If none exists, creates one using the supplier.
-     * Logs a warning if the new consumer's pool/timeout config differs from the first acquire.
      */
-    Redis acquire(String key, RedisCacheResourceConfiguration config, Supplier<Redis> clientSupplier) {
+    Redis acquire(String key, Supplier<Redis> clientSupplier) {
         RefCountedClient ref = clients.compute(key, (k, existing) -> {
             if (existing != null) {
                 existing.refCount.incrementAndGet();
-                warnOnPoolMismatch(config, existing.originalConfig, existing.refCount.get());
                 log.debug("Reusing shared Redis client, refCount={}, registrySize={}", existing.refCount.get(), clients.size());
                 return existing;
             }
             Redis client = clientSupplier.get();
             log.info("Created new shared Redis client, registrySize={}", clients.size() + 1);
-            return new RefCountedClient(client, config);
+            return new RefCountedClient(client);
         });
         return ref.client;
     }
@@ -120,52 +122,6 @@ class SharedRedisClientRegistry {
         return sb.toString();
     }
 
-    private static void warnOnPoolMismatch(
-        RedisCacheResourceConfiguration requested,
-        RedisCacheResourceConfiguration original,
-        int refCount
-    ) {
-        var mismatches = new ArrayList<String>();
-        if (requested.getMaxPoolSize() != original.getMaxPoolSize()) {
-            mismatches.add("maxPoolSize: requested=" + requested.getMaxPoolSize() + " vs active=" + original.getMaxPoolSize());
-        }
-        if (requested.getMaxPoolWaiting() != original.getMaxPoolWaiting()) {
-            mismatches.add("maxPoolWaiting: requested=" + requested.getMaxPoolWaiting() + " vs active=" + original.getMaxPoolWaiting());
-        }
-        if (requested.getPoolCleanerInterval() != original.getPoolCleanerInterval()) {
-            mismatches.add(
-                "poolCleanerInterval: requested=" + requested.getPoolCleanerInterval() + " vs active=" + original.getPoolCleanerInterval()
-            );
-        }
-        if (requested.getPoolRecycleTimeout() != original.getPoolRecycleTimeout()) {
-            mismatches.add(
-                "poolRecycleTimeout: requested=" + requested.getPoolRecycleTimeout() + " vs active=" + original.getPoolRecycleTimeout()
-            );
-        }
-        if (requested.getMaxWaitingHandlers() != original.getMaxWaitingHandlers()) {
-            mismatches.add(
-                "maxWaitingHandlers: requested=" + requested.getMaxWaitingHandlers() + " vs active=" + original.getMaxWaitingHandlers()
-            );
-        }
-        if (requested.getConnectTimeout() != original.getConnectTimeout()) {
-            mismatches.add("connectTimeout: requested=" + requested.getConnectTimeout() + " vs active=" + original.getConnectTimeout());
-        }
-        if (!mismatches.isEmpty()) {
-            String connection = original.getSentinel().isEnabled() || original.isSentinelMode()
-                ? "sentinel:" + original.getSentinel().getMasterId()
-                : original.getStandalone().getHost() + ":" + original.getStandalone().getPort();
-            log.warn(
-                "Shared Redis client for {} has pool/timeout settings mismatch. " +
-                    "First-acquire wins, these values from the new consumer are ignored: [{}]. " +
-                    "To align, ensure all resources pointing to this Redis use the same pool configuration. " +
-                    "Current shared client has {} active references.",
-                connection,
-                String.join(", ", mismatches),
-                refCount
-            );
-        }
-    }
-
     // Visible for testing
     int registrySize() {
         return clients.size();
@@ -175,12 +131,10 @@ class SharedRedisClientRegistry {
 
         final Redis client;
         final AtomicInteger refCount;
-        final RedisCacheResourceConfiguration originalConfig;
 
-        RefCountedClient(Redis client, RedisCacheResourceConfiguration originalConfig) {
+        RefCountedClient(Redis client) {
             this.client = client;
             this.refCount = new AtomicInteger(1);
-            this.originalConfig = originalConfig;
         }
     }
 }

--- a/src/main/java/io/gravitee/resource/cache/redis/configuration/RedisCacheResourceConfiguration.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/configuration/RedisCacheResourceConfiguration.java
@@ -41,14 +41,6 @@ public class RedisCacheResourceConfiguration implements ResourceConfiguration {
     private boolean releaseCache;
     private boolean useSsl = true;
 
-    // Pool and timeout settings (per-API; shared clients use first-acquire-wins, mismatches logged)
-    private int maxPoolSize = 6;
-    private int maxPoolWaiting = 1024;
-    private int poolCleanerInterval = 30000;
-    private int poolRecycleTimeout = 180000;
-    private int maxWaitingHandlers = 1024;
-    private int connectTimeout = 2000;
-
     @Deprecated
     private boolean sentinelMode = false;
 

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -87,60 +87,6 @@
                 }
             }
         },
-        "maxPoolSize": {
-            "title": "Max pool size",
-            "description": "Maximum number of connections in the pool. (Supports EL)",
-            "type": "integer",
-            "default": 6,
-            "gioConfig": {
-                "el": true
-            }
-        },
-        "maxPoolWaiting": {
-            "title": "Max pool waiting",
-            "description": "Maximum number of requests waiting for a connection from the pool. (Supports EL)",
-            "type": "integer",
-            "default": 1024,
-            "gioConfig": {
-                "el": true
-            }
-        },
-        "poolCleanerInterval": {
-            "title": "Pool cleaner interval (ms)",
-            "description": "Interval in milliseconds between pool cleaner runs. (Supports EL)",
-            "type": "integer",
-            "default": 30000,
-            "gioConfig": {
-                "el": true
-            }
-        },
-        "poolRecycleTimeout": {
-            "title": "Pool recycle timeout (ms)",
-            "description": "Timeout in milliseconds for recycling idle connections. (Supports EL)",
-            "type": "integer",
-            "default": 180000,
-            "gioConfig": {
-                "el": true
-            }
-        },
-        "maxWaitingHandlers": {
-            "title": "Max waiting handlers",
-            "description": "Maximum number of waiting handlers for the Redis client. (Supports EL)",
-            "type": "integer",
-            "default": 1024,
-            "gioConfig": {
-                "el": true
-            }
-        },
-        "connectTimeout": {
-            "title": "Connect timeout (ms)",
-            "description": "Maximum time in milliseconds to establish a connection. (Supports EL)",
-            "type": "integer",
-            "default": 2000,
-            "gioConfig": {
-                "el": true
-            }
-        },
         "sentinel": {
             "type": "object",
             "oneOf": [

--- a/src/test/java/io/gravitee/resource/cache/redis/RedisCacheGlobalOptionsTest.java
+++ b/src/test/java/io/gravitee/resource/cache/redis/RedisCacheGlobalOptionsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.cache.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+/**
+ * Guards the exact property keys read by {@link RedisCacheGlobalOptions}. A typo in any
+ * {@code resources.cacheRedis.*} key would otherwise be silently invisible: the class
+ * falls back to its hard-coded defaults, operators set a value in {@code gravitee.yml},
+ * and the gateway would keep running on the old default with no error.
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RedisCacheGlobalOptionsTest {
+
+    @Test
+    void should_use_hard_coded_defaults_when_no_properties_are_set() {
+        var options = new RedisCacheGlobalOptions(new StandardEnvironment());
+
+        assertThat(options.getMaxPoolSize()).isEqualTo(6);
+        assertThat(options.getMaxPoolWaiting()).isEqualTo(1024);
+        assertThat(options.getPoolCleanerInterval()).isEqualTo(30000);
+        assertThat(options.getPoolRecycleTimeout()).isEqualTo(180000);
+        assertThat(options.getMaxWaitingHandlers()).isEqualTo(1024);
+        assertThat(options.getConnectTimeout()).isEqualTo(2000);
+    }
+
+    @Test
+    void should_read_every_property_from_environment_using_documented_keys() {
+        var env = environmentWith(
+            Map.of(
+                "resources.cacheRedis.maxPoolSize",
+                42,
+                "resources.cacheRedis.maxPoolWaiting",
+                43,
+                "resources.cacheRedis.poolCleanerInterval",
+                44,
+                "resources.cacheRedis.poolRecycleTimeout",
+                45,
+                "resources.cacheRedis.maxWaitingHandlers",
+                46,
+                "resources.cacheRedis.connectTimeout",
+                47
+            )
+        );
+
+        var options = new RedisCacheGlobalOptions(env);
+
+        assertThat(options.getMaxPoolSize()).isEqualTo(42);
+        assertThat(options.getMaxPoolWaiting()).isEqualTo(43);
+        assertThat(options.getPoolCleanerInterval()).isEqualTo(44);
+        assertThat(options.getPoolRecycleTimeout()).isEqualTo(45);
+        assertThat(options.getMaxWaitingHandlers()).isEqualTo(46);
+        assertThat(options.getConnectTimeout()).isEqualTo(47);
+    }
+
+    private static StandardEnvironment environmentWith(Map<String, Object> properties) {
+        var env = new StandardEnvironment();
+        env.getPropertySources().addFirst(new MapPropertySource("test", properties));
+        return env;
+    }
+}

--- a/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceIntegrationTest.java
+++ b/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceIntegrationTest.java
@@ -180,6 +180,15 @@ class RedisCacheResourceIntegrationTest {
     private ApplicationContext mockApplicationContext() {
         ApplicationContext ctx = mock(ApplicationContext.class);
         when(ctx.getBean(Vertx.class)).thenReturn(vertx);
+        org.springframework.core.env.Environment env = mock(org.springframework.core.env.Environment.class);
+        when(
+            env.getProperty(
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.eq(Integer.class),
+                org.mockito.ArgumentMatchers.anyInt()
+            )
+        ).thenAnswer(inv -> inv.getArgument(2));
+        when(ctx.getEnvironment()).thenReturn(env);
         return ctx;
     }
 }

--- a/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceTest.java
+++ b/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceTest.java
@@ -297,6 +297,15 @@ class RedisCacheResourceTest {
     private ApplicationContext mockApplicationContext() {
         ApplicationContext ctx = mock(ApplicationContext.class);
         when(ctx.getBean(Vertx.class)).thenReturn(vertx);
+        org.springframework.core.env.Environment env = mock(org.springframework.core.env.Environment.class);
+        when(
+            env.getProperty(
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.eq(Integer.class),
+                org.mockito.ArgumentMatchers.anyInt()
+            )
+        ).thenAnswer(inv -> inv.getArgument(2));
+        when(ctx.getEnvironment()).thenReturn(env);
         return ctx;
     }
 }


### PR DESCRIPTION
## Summary

Reverts `6b98fb9` (never released) which moved pool / timeout settings from `gravitee.yml` into the per-API resource form. Those fields always lied to the operator — the shared client registry (APIM-13629) dedups by connection tuple only, and Vert.x Redis pools cannot be resized after construction, so per-API pool values were silently ignored once a shared client was already active. The result: editing `maxPoolSize` in the UI logged a "pool/timeout settings mismatch" warning and nothing changed. See the empirical test report at `/tmp/apim-13700-test/TEST_REPORT.md` (APIM-13700 run) for the repro.

## Changes

- **Remove** 6 fields from `RedisCacheResourceConfiguration`: `maxPoolSize`, `maxPoolWaiting`, `poolCleanerInterval`, `poolRecycleTimeout`, `maxWaitingHandlers`, `connectTimeout`. (No `@Deprecated` — these never shipped to a real release; only introduced in `6b98fb9` → 4.2.0 which is still gated pending APIM-13553.)
- **New** `RedisCacheGlobalOptions`: reads the six values from Spring `Environment` under `resources.cacheRedis.*` with the original hard-coded defaults (6 / 1024 / 30000 / 180000 / 1024 / 2000).
- **`RedisCacheResource`** injects `Environment` via the existing `applicationContext.getBean(...)` pattern and builds `RedisOptions` from `RedisCacheGlobalOptions` instead of from the per-API config.
- **`SharedRedisClientRegistry`** simplified: no more `warnOnPoolMismatch` (impossible now — every consumer reads the same global config).
- **`schema-form.json`** drops the six fields → UI no longer shows them, no more edit-button-lying.
- Existing stored API definitions with the old fields deserialize fine (Jackson drops unknown properties per the 4.10 `FAIL_ON_UNKNOWN_PROPERTIES=false` gateway setting).

## Operator migration

Update `gravitee.yml` once per gateway:
```yaml
resources:
  cacheRedis:
    maxPoolSize: 60
    maxPoolWaiting: 1024
    poolCleanerInterval: 30000
    poolRecycleTimeout: 180000
    maxWaitingHandlers: 1024
    connectTimeout: 2000
```
Gateway restart picks up the new pool size. To change again later: edit `gravitee.yml`, restart. No per-API surgery.

## Why not dynamic pool resize?

Investigated. Vert.x `Redis.createClient(vertx, options)` snapshots `PoolOptions.maxSize` at construction into `ConnectionPool.pool(connector, new int[]{maxSize}, ...)` — captured as a primitive int, no re-read path. Mutating `PoolOptions` after create is a no-op against the live pool. So "apply new pool size at runtime" is only achievable by constructing a fresh client and migrating consumers (swap-and-drain), which carries its own mixed-state window and complexity. Gateway-wide config + restart is the simpler, predictable path.

## Test plan

- [x] `mvn test` — 10/10 unit tests passing locally
- [x] Built `gravitee-resource-cache-redis-4.2.0.zip` from this branch
- [x] Swapped into a worktree gateway + MAPI running APIM 4.10.12
- [x] `gravitee.yml` set `resources.cacheRedis.maxPoolSize: 60`
- [x] Zero "pool/timeout settings mismatch" warnings since patched boot (6 from prior stock runs all pre-patch)
- [x] Under `hey -c 40 -z 10s` load on oauth2-v4-redis: Redis `CLIENT LIST` grew from 2 → 40 live connections (pool scales), 13,998 reqs / 0 errors / 1293 rps
- [x] After load stops + ~4 min idle: `CLIENT LIST` drops to 1 (just `redis-cli`), confirming `poolRecycleTimeout=180s` + `poolCleanerInterval=30s` eviction works as documented
- [x] Round-trip GET → modify TTL → PUT through MAPI v2 endpoints succeeds for all 12 test APIs (no schema-drift rejections on existing configs)
- [ ] CI green

## Follow-up

- Same change needs to land on `alpha` — will open a companion PR.
- `gravitee-apim` docs / default `gravitee.yml` stub should mention the new `resources.cacheRedis.*` block in the release notes.

Related: APIM-13553, APIM-13556, APIM-13629, APIM-13700 (test repro).
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.2.1-wba-global-pool-config-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache-redis/4.2.1-wba-global-pool-config-SNAPSHOT/gravitee-resource-cache-redis-4.2.1-wba-global-pool-config-SNAPSHOT.zip)
  <!-- Version placeholder end -->
