### PR TITLE
refactor(redis-cache): move pool/timeout config to gravitee.yml

### DIFF
--- a/src/main/java/io/gravitee/resource/cache/redis/RedisCacheGlobalOptions.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/RedisCacheGlobalOptions.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.cache.redis;
+
+import io.gravitee.plugin.configurations.redis.RedisClientOptions;
+import lombok.Getter;
+import org.springframework.core.env.Environment;
+
+/**
+ * Gateway-wide Redis cache client settings, sourced from {@code gravitee.yml}
+ * under the {@code resources.cacheRedis.*} prefix.
+ *
+ * <p>These fields are connection-pool and timeout settings that must be uniform
+ * across every {@code cache-redis} resource targeting the same Redis endpoint.
+ * The shared {@link io.gravitee.node.vertx.client.redis.VertxRedisClientFactory}
+ * dedups by connection tuple; Vert.x Redis does not support runtime pool resize.
+ * Placing the pool/timeout settings in {@code gravitee.yml} instead of per-resource
+ * JSON means they really are global — there is no UI field that looks editable but
+ * is silently ignored.
+ *
+ * <p>Example {@code gravitee.yml}:
+ * <pre>
+ * resources:
+ *   cacheRedis:
+ *     maxPoolSize: 60
+ *     maxPoolWaiting: 1024
+ *     poolCleanerInterval: 30000
+ *     poolRecycleTimeout: 180000
+ *     maxWaitingHandlers: 1024
+ *     connectTimeout: 2000
+ * </pre>
+ */
+@Getter
+public final class RedisCacheGlobalOptions {
+
+    private static final String PREFIX = "resources.cacheRedis.";
+
+    private final int maxPoolSize;
+    private final int maxPoolWaiting;
+    private final int poolCleanerInterval;
+    private final int poolRecycleTimeout;
+    private final int maxWaitingHandlers;
+    private final int connectTimeout;
+
+    public RedisCacheGlobalOptions(Environment environment) {
+        this.maxPoolSize = environment.getProperty(PREFIX + "maxPoolSize", Integer.class, RedisClientOptions.DEFAULT_MAX_POOL_SIZE);
+        this.maxPoolWaiting = environment.getProperty(
+            PREFIX + "maxPoolWaiting",
+            Integer.class,
+            RedisClientOptions.DEFAULT_MAX_POOL_WAITING
+        );
+        this.poolCleanerInterval = environment.getProperty(
+            PREFIX + "poolCleanerInterval",
+            Integer.class,
+            RedisClientOptions.DEFAULT_POOL_CLEANER_INTERVAL
+        );
+        this.poolRecycleTimeout = environment.getProperty(
+            PREFIX + "poolRecycleTimeout",
+            Integer.class,
+            RedisClientOptions.DEFAULT_POOL_RECYCLE_TIMEOUT
+        );
+        this.maxWaitingHandlers = environment.getProperty(
+            PREFIX + "maxWaitingHandlers",
+            Integer.class,
+            RedisClientOptions.DEFAULT_MAX_WAITING_HANDLERS
+        );
+        this.connectTimeout = environment.getProperty(PREFIX + "connectTimeout", Integer.class, RedisClientOptions.DEFAULT_CONNECT_TIMEOUT);
+    }
+}

--- a/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
@@ -54,6 +54,7 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
     private DeploymentContext deploymentContext;
 
     private RedisCacheResourceConfiguration configuration;
+    private RedisCacheGlobalOptions globalOptions;
     private volatile Redis redisClient;
     private volatile RedisAPI redisAPI;
     private RedisClientOptions redisClientOptions;
@@ -72,6 +73,7 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
         log.debug("Create redis cache resource");
 
         configuration = new RedisCacheResourceConfigurationEvaluator(configuration()).evalNow(deploymentContext);
+        globalOptions = new RedisCacheGlobalOptions(applicationContext.getEnvironment());
 
         redisClientOptions = buildRedisClientOptions();
         redisClient = getOrCreateFactory().acquire(redisClientOptions);
@@ -180,12 +182,12 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
             builder.ssl(sslOptions);
         }
 
-        builder.maxPoolSize(configuration.getMaxPoolSize());
-        builder.maxPoolWaiting(configuration.getMaxPoolWaiting());
-        builder.poolCleanerInterval(configuration.getPoolCleanerInterval());
-        builder.poolRecycleTimeout(configuration.getPoolRecycleTimeout());
-        builder.maxWaitingHandlers(configuration.getMaxWaitingHandlers());
-        builder.connectTimeout(configuration.getConnectTimeout());
+        builder.maxPoolSize(globalOptions.getMaxPoolSize());
+        builder.maxPoolWaiting(globalOptions.getMaxPoolWaiting());
+        builder.poolCleanerInterval(globalOptions.getPoolCleanerInterval());
+        builder.poolRecycleTimeout(globalOptions.getPoolRecycleTimeout());
+        builder.maxWaitingHandlers(globalOptions.getMaxWaitingHandlers());
+        builder.connectTimeout(globalOptions.getConnectTimeout());
 
         return builder.build();
     }

--- a/src/main/java/io/gravitee/resource/cache/redis/configuration/RedisCacheResourceConfiguration.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/configuration/RedisCacheResourceConfiguration.java
@@ -17,9 +17,9 @@ package io.gravitee.resource.cache.redis.configuration;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import io.gravitee.plugin.annotation.ConfigurationEvaluator;
-import io.gravitee.plugin.configurations.redis.RedisClientOptions;
 import io.gravitee.plugin.configurations.ssl.SslOptions;
 import io.gravitee.resource.api.ResourceConfiguration;
 import io.gravitee.secrets.api.annotation.Secret;
@@ -37,6 +37,7 @@ import lombok.Setter;
 @ConfigurationEvaluator
 @Getter
 @Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class RedisCacheResourceConfiguration implements ResourceConfiguration {
 
     // Redis connection fields (aligned with RedisClientOptions shape)
@@ -49,14 +50,6 @@ public class RedisCacheResourceConfiguration implements ResourceConfiguration {
     private boolean useSsl = true;
     private SslOptions ssl;
     private RedisSentinelConfiguration sentinel = new RedisSentinelConfiguration();
-
-    // Pool settings (per-API; shared clients use first-acquire-wins, mismatches logged as warning)
-    private int maxPoolSize = RedisClientOptions.DEFAULT_MAX_POOL_SIZE;
-    private int maxPoolWaiting = RedisClientOptions.DEFAULT_MAX_POOL_WAITING;
-    private int poolCleanerInterval = RedisClientOptions.DEFAULT_POOL_CLEANER_INTERVAL;
-    private int poolRecycleTimeout = RedisClientOptions.DEFAULT_POOL_RECYCLE_TIMEOUT;
-    private int maxWaitingHandlers = RedisClientOptions.DEFAULT_MAX_WAITING_HANDLERS;
-    private int connectTimeout = RedisClientOptions.DEFAULT_CONNECT_TIMEOUT;
 
     // Cache-specific fields
     private long timeToLiveSeconds;

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -28,24 +28,6 @@
         "sentinel": {
             "$ref": "#/gioExternalDefinitions/redisSentinel"
         },
-        "maxPoolSize": {
-            "$ref": "#/gioExternalDefinitions/redisMaxPoolSize"
-        },
-        "maxPoolWaiting": {
-            "$ref": "#/gioExternalDefinitions/redisMaxPoolWaiting"
-        },
-        "poolCleanerInterval": {
-            "$ref": "#/gioExternalDefinitions/redisPoolCleanerInterval"
-        },
-        "poolRecycleTimeout": {
-            "$ref": "#/gioExternalDefinitions/redisPoolRecycleTimeout"
-        },
-        "maxWaitingHandlers": {
-            "$ref": "#/gioExternalDefinitions/redisMaxWaitingHandlers"
-        },
-        "connectTimeout": {
-            "$ref": "#/gioExternalDefinitions/redisConnectTimeout"
-        },
         "releaseCache": {
             "title": "Release the cache when API is stopped?",
             "description": "If enabled, the resource will release the cache. If not, you will have to manage it by yourself on your Redis server.",

--- a/src/test/java/io/gravitee/resource/cache/redis/RedisCacheGlobalOptionsTest.java
+++ b/src/test/java/io/gravitee/resource/cache/redis/RedisCacheGlobalOptionsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.cache.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.plugin.configurations.redis.RedisClientOptions;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+/**
+ * Guards the exact property keys read by {@link RedisCacheGlobalOptions}. A typo in any
+ * {@code resources.cacheRedis.*} key would otherwise be silently invisible: the class
+ * falls back to its hard-coded defaults, operators set a value in {@code gravitee.yml},
+ * and the gateway would keep running on the old default with no error.
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RedisCacheGlobalOptionsTest {
+
+    @Test
+    void should_use_upstream_defaults_when_no_properties_are_set() {
+        var options = new RedisCacheGlobalOptions(new StandardEnvironment());
+
+        assertThat(options.getMaxPoolSize()).isEqualTo(RedisClientOptions.DEFAULT_MAX_POOL_SIZE);
+        assertThat(options.getMaxPoolWaiting()).isEqualTo(RedisClientOptions.DEFAULT_MAX_POOL_WAITING);
+        assertThat(options.getPoolCleanerInterval()).isEqualTo(RedisClientOptions.DEFAULT_POOL_CLEANER_INTERVAL);
+        assertThat(options.getPoolRecycleTimeout()).isEqualTo(RedisClientOptions.DEFAULT_POOL_RECYCLE_TIMEOUT);
+        assertThat(options.getMaxWaitingHandlers()).isEqualTo(RedisClientOptions.DEFAULT_MAX_WAITING_HANDLERS);
+        assertThat(options.getConnectTimeout()).isEqualTo(RedisClientOptions.DEFAULT_CONNECT_TIMEOUT);
+    }
+
+    @Test
+    void should_read_every_property_from_environment_using_documented_keys() {
+        var env = environmentWith(
+            Map.of(
+                "resources.cacheRedis.maxPoolSize",
+                42,
+                "resources.cacheRedis.maxPoolWaiting",
+                43,
+                "resources.cacheRedis.poolCleanerInterval",
+                44,
+                "resources.cacheRedis.poolRecycleTimeout",
+                45,
+                "resources.cacheRedis.maxWaitingHandlers",
+                46,
+                "resources.cacheRedis.connectTimeout",
+                47
+            )
+        );
+
+        var options = new RedisCacheGlobalOptions(env);
+
+        assertThat(options.getMaxPoolSize()).isEqualTo(42);
+        assertThat(options.getMaxPoolWaiting()).isEqualTo(43);
+        assertThat(options.getPoolCleanerInterval()).isEqualTo(44);
+        assertThat(options.getPoolRecycleTimeout()).isEqualTo(45);
+        assertThat(options.getMaxWaitingHandlers()).isEqualTo(46);
+        assertThat(options.getConnectTimeout()).isEqualTo(47);
+    }
+
+    private static StandardEnvironment environmentWith(Map<String, Object> properties) {
+        var env = new StandardEnvironment();
+        env.getPropertySources().addFirst(new MapPropertySource("test", properties));
+        return env;
+    }
+}

--- a/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceIntegrationTest.java
+++ b/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceIntegrationTest.java
@@ -186,6 +186,15 @@ class RedisCacheResourceIntegrationTest {
     private ApplicationContext mockApplicationContext() {
         ApplicationContext ctx = mock(ApplicationContext.class);
         when(ctx.getBean(Vertx.class)).thenReturn(vertx);
+        org.springframework.core.env.Environment env = mock(org.springframework.core.env.Environment.class);
+        when(
+            env.getProperty(
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.eq(Integer.class),
+                org.mockito.ArgumentMatchers.anyInt()
+            )
+        ).thenAnswer(inv -> inv.getArgument(2));
+        when(ctx.getEnvironment()).thenReturn(env);
         return ctx;
     }
 }

--- a/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceTest.java
+++ b/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceTest.java
@@ -37,6 +37,7 @@ import io.vertx.redis.client.Redis;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.*;
 import org.springframework.context.ApplicationContext;
 
@@ -295,42 +296,25 @@ class RedisCacheResourceTest {
     }
 
     @Test
-    void should_share_client_when_only_pool_config_differs() throws Exception {
-        RedisCacheResourceConfiguration config1 = new RedisCacheResourceConfiguration();
-        config1.setMaxPoolSize(10);
-
-        RedisCacheResourceConfiguration config2 = new RedisCacheResourceConfiguration();
-        config2.setMaxPoolSize(20);
-
-        RedisCacheResource resource1 = underTest(config1);
-        RedisCacheResource resource2 = underTest(config2);
-
-        resource1.start();
-        resource2.start();
-
-        // Pool config is NOT part of the dedup key — same host/port/ssl/password → one client,
-        // first-acquire-wins for pool sizing (upstream VertxRedisClientFactory logs a warn).
-        Field clientField = RedisCacheResource.class.getDeclaredField("redisClient");
-        clientField.setAccessible(true);
-        assertThat(clientField.get(resource1)).isSameAs(clientField.get(resource2));
-        assertThat(TestFactoryAccess.sharedClientCount()).isEqualTo(1);
-
-        resource1.stop();
-        resource2.stop();
-        assertThat(TestFactoryAccess.sharedClientCount()).isZero();
-    }
-
-    @Test
-    void should_propagate_pool_settings_to_client_options() throws Exception {
+    void should_propagate_global_pool_settings_to_client_options() throws Exception {
         RedisCacheResourceConfiguration config = new RedisCacheResourceConfiguration();
-        config.setMaxPoolSize(42);
-        config.setMaxPoolWaiting(43);
-        config.setPoolCleanerInterval(44);
-        config.setPoolRecycleTimeout(45);
-        config.setMaxWaitingHandlers(46);
-        config.setConnectTimeout(47);
-
-        RedisCacheResource resource = underTest(config);
+        RedisCacheResource resource = underTestWithGlobalOptions(
+            config,
+            Map.of(
+                "resources.cacheRedis.maxPoolSize",
+                42,
+                "resources.cacheRedis.maxPoolWaiting",
+                43,
+                "resources.cacheRedis.poolCleanerInterval",
+                44,
+                "resources.cacheRedis.poolRecycleTimeout",
+                45,
+                "resources.cacheRedis.maxWaitingHandlers",
+                46,
+                "resources.cacheRedis.connectTimeout",
+                47
+            )
+        );
         resource.start();
 
         Field optionsField = RedisCacheResource.class.getDeclaredField("redisClientOptions");
@@ -475,11 +459,11 @@ class RedisCacheResourceTest {
 
     @Test
     void should_silently_ignore_legacy_maxTotal_on_deserialization() throws Exception {
-        String json = "{\"maxTotal\":200}";
+        // Deserialization must not fail with unknown/legacy fields; pool settings now live in
+        // gravitee.yml, not on the per-resource config.
+        String json = "{\"maxTotal\":200,\"maxPoolSize\":999,\"connectTimeout\":7777}";
         RedisCacheResourceConfiguration cfg = new ObjectMapper().readValue(json, RedisCacheResourceConfiguration.class);
-
-        // maxPoolSize should remain at its default, not be 200
-        assertThat(cfg.getMaxPoolSize()).isNotEqualTo(200);
+        assertThat(cfg).isNotNull();
     }
 
     private static HostAndPort hostAndPort(String host, int port) {
@@ -494,18 +478,36 @@ class RedisCacheResourceTest {
     }
 
     RedisCacheResource underTest(RedisCacheResourceConfiguration config) throws IllegalAccessException, NoSuchFieldException {
+        return underTestWithGlobalOptions(config, java.util.Map.of());
+    }
+
+    RedisCacheResource underTestWithGlobalOptions(RedisCacheResourceConfiguration config, java.util.Map<String, Integer> globalOverrides)
+        throws IllegalAccessException, NoSuchFieldException {
         RedisCacheResource redisCacheResource = new RedisCacheResource();
         Field configurationField = AbstractConfigurableResource.class.getDeclaredField("configuration");
         configurationField.setAccessible(true);
         configurationField.set(redisCacheResource, config);
         redisCacheResource.setDeploymentContext(new TestDeploymentContext(templateEngine));
-        redisCacheResource.setApplicationContext(mockApplicationContext());
+        redisCacheResource.setApplicationContext(mockApplicationContext(globalOverrides));
         return redisCacheResource;
     }
 
-    private ApplicationContext mockApplicationContext() {
+    private ApplicationContext mockApplicationContext(java.util.Map<String, Integer> globalOverrides) {
         ApplicationContext ctx = mock(ApplicationContext.class);
         when(ctx.getBean(Vertx.class)).thenReturn(vertx);
+        org.springframework.core.env.Environment env = mock(org.springframework.core.env.Environment.class);
+        when(
+            env.getProperty(
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.eq(Integer.class),
+                org.mockito.ArgumentMatchers.anyInt()
+            )
+        ).thenAnswer(inv -> {
+            String key = inv.getArgument(0);
+            Integer override = globalOverrides.get(key);
+            return override != null ? override : inv.getArgument(2);
+        });
+        when(ctx.getEnvironment()).thenReturn(env);
         return ctx;
     }
 }


### PR DESCRIPTION
## Summary

Companion to #82 (master). Same change applied on top of alpha's newer `VertxRedisClientFactory` architecture (APIM-13603). Pool/timeout fields are removed from the per-API resource schema and are now sourced exclusively from `gravitee.yml` under `resources.cacheRedis.*`, because Vert.x Redis does not support runtime pool resize and per-API values were silently ignored once a shared client was active — see #82 for the full analysis and APIM-13700 test repro.

## Changes

- **Remove** 6 fields from `RedisCacheResourceConfiguration`: `maxPoolSize`, `maxPoolWaiting`, `poolCleanerInterval`, `poolRecycleTimeout`, `maxWaitingHandlers`, `connectTimeout`.
- **Add** `@JsonIgnoreProperties(ignoreUnknown = true)` on `RedisCacheResourceConfiguration` so legacy stored API definitions with those fields still deserialize cleanly during the rolling upgrade.
- **New** `RedisCacheGlobalOptions` reads values from Spring `Environment` under `resources.cacheRedis.*`, defaulting to the existing `RedisClientOptions.DEFAULT_*` constants from `gravitee-plugin-common-configurations`.
- **`RedisCacheResource.buildRedisClientOptions()`** feeds the `RedisClientOptions.builder()` from `RedisCacheGlobalOptions` instead of per-API config.
- **`schema-form.json`** drops the 6 field refs → UI no longer exposes them.
- Tests updated: new `underTestWithGlobalOptions(...)` helper lets individual tests override specific `resources.cacheRedis.*` keys; deleted the now-obsolete `should_share_client_when_only_pool_config_differs` (the scenario it asserts can no longer arise).

## Why this is different from #82

Master still uses a local `SharedRedisClientRegistry`. Alpha delegates to `gravitee-node`'s `VertxRedisClientFactory` which has its own first-acquire-wins semantics. This PR makes the alpha plugin pass the same global pool values through the factory — so the factory never sees a mismatch and its warning stays silent by construction.

## Operator migration

Same as #82:
```yaml
resources:
  cacheRedis:
    maxPoolSize: 60
    maxPoolWaiting: 1024
    poolCleanerInterval: 30000
    poolRecycleTimeout: 180000
    maxWaitingHandlers: 1024
    connectTimeout: 2000
```

## Test plan

- [x] `mvn test` — 20/20 unit tests passing locally (including new global-options test and the legacy-field deserialization test)
- [ ] CI green
- [ ] Integration test in APIM 4.12 alpha worktree (requires APIM-13603 factory; the master equivalent was tested under APIM 4.10.12 + apim-13700-test worktree, see `/tmp/apim-13700-test/TEST_REPORT.md` on the testing machine)

Related: APIM-13553, APIM-13556, APIM-13603, APIM-13629, APIM-13700 (test repro), #82 (master counterpart).
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.0-wba-global-pool-config-alpha-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache-redis/5.0.0-wba-global-pool-config-alpha-SNAPSHOT/gravitee-resource-cache-redis-5.0.0-wba-global-pool-config-alpha-SNAPSHOT.zip)
  <!-- Version placeholder end -->
