### PR TITLE
feat(redis-cache): override getBinaryAsync/putBinaryAsync for binary-safe values (APIM-13628)

### DIFF
--- a/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/RedisCacheResource.java
@@ -126,7 +126,7 @@ public class RedisCacheResource extends CacheResource<RedisCacheResourceConfigur
 
     private Cache getCache(Map<String, Object> contextAttributes) {
         return new RedisDelegate(
-            redisAPI,
+            redisClient,
             "gravitee:",
             contextAttributes,
             (int) configuration().getTimeToLiveSeconds(),

--- a/src/main/java/io/gravitee/resource/cache/redis/RedisDelegate.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/RedisDelegate.java
@@ -20,7 +20,10 @@ import io.gravitee.resource.cache.api.Cache;
 import io.gravitee.resource.cache.api.Element;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
+import io.vertx.redis.client.Command;
+import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisAPI;
+import io.vertx.redis.client.Request;
 import io.vertx.redis.client.Response;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,22 +31,38 @@ import java.util.Map;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import lombok.CustomLog;
-import lombok.RequiredArgsConstructor;
 
 /**
  * @author Guillaume CUSNIEUX (guillaume.cusnieux at graviteesource.com)
  * @author GraviteeSource Team
  */
 @CustomLog
-@RequiredArgsConstructor
 public class RedisDelegate implements Cache {
 
+    private final Redis redisClient;
     private final RedisAPI redisAPI;
     private final String cacheName;
     private final Map<String, Object> contextAttributes;
     private final int timeToLiveSeconds;
     private final boolean releaseCache;
     private final long commandTimeoutMs;
+
+    public RedisDelegate(
+        Redis redisClient,
+        String cacheName,
+        Map<String, Object> contextAttributes,
+        int timeToLiveSeconds,
+        boolean releaseCache,
+        long commandTimeoutMs
+    ) {
+        this.redisClient = redisClient;
+        this.redisAPI = RedisAPI.api(redisClient);
+        this.cacheName = cacheName;
+        this.contextAttributes = contextAttributes;
+        this.timeToLiveSeconds = timeToLiveSeconds;
+        this.releaseCache = releaseCache;
+        this.commandTimeoutMs = commandTimeoutMs;
+    }
 
     @Override
     public String getName() {
@@ -100,6 +119,37 @@ public class RedisDelegate implements Cache {
             future = redisAPI.set(List.of(redisKey, value));
         }
         return future.timeout(commandTimeoutMs, TimeUnit.MILLISECONDS).mapEmpty();
+    }
+
+    @Override
+    public Future<Element> getBinaryAsync(Object key) {
+        String redisKey = buildKey(key);
+        Request request = Request.cmd(Command.GET).arg(redisKey);
+        return redisClient
+            .send(request)
+            .timeout(commandTimeoutMs, TimeUnit.MILLISECONDS)
+            .map(response -> response != null ? toElement(key, response.toBytes()) : null);
+    }
+
+    @Override
+    public Future<Void> putBinaryAsync(Element element) {
+        Object raw = element.value();
+        if (!(raw instanceof byte[] value)) {
+            return Future.failedFuture(
+                new IllegalArgumentException(
+                    "putBinaryAsync requires byte[] value for key '" +
+                        element.key() +
+                        "', got " +
+                        (raw == null ? "null" : raw.getClass().getName())
+                )
+            );
+        }
+        int ttl = resolveTtl(element);
+        String redisKey = buildKey(element.key());
+        Request request = ttl > 0
+            ? Request.cmd(Command.SETEX).arg(redisKey).arg(String.valueOf(ttl)).arg(value)
+            : Request.cmd(Command.SET).arg(redisKey).arg(value);
+        return redisClient.send(request).timeout(commandTimeoutMs, TimeUnit.MILLISECONDS).mapEmpty();
     }
 
     @Override
@@ -190,7 +240,7 @@ public class RedisDelegate implements Cache {
         return ttl;
     }
 
-    private static Element toElement(Object key, String value) {
+    private static Element toElement(Object key, Object value) {
         return new Element() {
             @Override
             public Object key() {

--- a/src/test/java/io/gravitee/resource/cache/redis/RedisDelegateIntegrationTest.java
+++ b/src/test/java/io/gravitee/resource/cache/redis/RedisDelegateIntegrationTest.java
@@ -68,7 +68,7 @@ class RedisDelegateIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        delegate = new RedisDelegate(redisAPI, "gravitee:", Map.of(), 60, false, 2000L);
+        delegate = new RedisDelegate(redisClient, "gravitee:", Map.of(), 60, false, 2000L);
     }
 
     @AfterEach
@@ -136,7 +136,7 @@ class RedisDelegateIntegrationTest {
     @Test
     void clear_should_delete_only_current_deployment_keys_when_releaseCache_true() throws Exception {
         RedisDelegate scopedDelegate = new RedisDelegate(
-            redisAPI,
+            redisClient,
             "gravitee:",
             Map.of(ExecutionContext.ATTR_API_DEPLOYED_AT, "deploy-A"),
             60,
@@ -144,7 +144,7 @@ class RedisDelegateIntegrationTest {
             2000L
         );
         RedisDelegate otherDeployment = new RedisDelegate(
-            redisAPI,
+            redisClient,
             "gravitee:",
             Map.of(ExecutionContext.ATTR_API_DEPLOYED_AT, "deploy-B"),
             60,
@@ -170,6 +170,92 @@ class RedisDelegateIntegrationTest {
             .toCompletableFuture()
             .get(2, TimeUnit.SECONDS);
         assertThat(survivor.toString()).isEqualTo("kept");
+    }
+
+    @Test
+    void should_round_trip_binary_value_byte_identical() throws Exception {
+        byte[] payload = new byte[1024];
+        for (int i = 0; i < payload.length; i++) {
+            payload[i] = (byte) i;
+        }
+
+        delegate.putBinaryAsync(element("bin-1", payload, 0)).toCompletionStage().toCompletableFuture().get(2, TimeUnit.SECONDS);
+
+        Element retrieved = delegate.getBinaryAsync("bin-1").toCompletionStage().toCompletableFuture().get(2, TimeUnit.SECONDS);
+
+        assertThat(retrieved).isNotNull();
+        assertThat(retrieved.value()).isInstanceOf(byte[].class);
+        assertThat((byte[]) retrieved.value()).isEqualTo(payload);
+    }
+
+    @Test
+    void should_preserve_non_utf8_bytes_via_binary_path() throws Exception {
+        byte[] payload = new byte[] { (byte) 0xC0, (byte) 0xC1, (byte) 0xF5, (byte) 0xFF, 0x00, 0x01 };
+
+        delegate.putBinaryAsync(element("bin-2", payload, 0)).toCompletionStage().toCompletableFuture().get(2, TimeUnit.SECONDS);
+
+        Element retrieved = delegate.getBinaryAsync("bin-2").toCompletionStage().toCompletableFuture().get(2, TimeUnit.SECONDS);
+
+        assertThat((byte[]) retrieved.value()).isEqualTo(payload);
+    }
+
+    @Test
+    void getBinaryAsync_should_return_null_when_missing() throws Exception {
+        Element retrieved = delegate.getBinaryAsync("absent").toCompletionStage().toCompletableFuture().get(2, TimeUnit.SECONDS);
+
+        assertThat(retrieved).isNull();
+    }
+
+    @Test
+    void putBinaryAsync_should_honor_ttl() throws Exception {
+        byte[] payload = new byte[] { 1, 2, 3 };
+        delegate.putBinaryAsync(element("bin-ttl", payload, 1)).toCompletionStage().toCompletableFuture().get(2, TimeUnit.SECONDS);
+
+        long ttl = redisAPI.ttl("gravitee:bin-ttl").toCompletionStage().toCompletableFuture().get(2, TimeUnit.SECONDS).toLong();
+
+        assertThat(ttl).isBetween(1L, 60L);
+    }
+
+    @Test
+    void putBinaryAsync_should_use_plain_set_when_ttl_zero() throws Exception {
+        // ttl=0 and default TTL=0 ⇒ resolveTtl returns 0 ⇒ plain SET branch (no expiry).
+        RedisDelegate noTtlDelegate = new RedisDelegate(redisClient, "gravitee:", Map.of(), 0, false, 2000L);
+        byte[] payload = new byte[] { 4, 5, 6 };
+
+        noTtlDelegate.putBinaryAsync(element("bin-no-ttl", payload, 0)).toCompletionStage().toCompletableFuture().get(2, TimeUnit.SECONDS);
+
+        long ttl = redisAPI.ttl("gravitee:bin-no-ttl").toCompletionStage().toCompletableFuture().get(2, TimeUnit.SECONDS).toLong();
+        // -1 = key exists, no associated TTL
+        assertThat(ttl).isEqualTo(-1L);
+
+        Element retrieved = noTtlDelegate.getBinaryAsync("bin-no-ttl").toCompletionStage().toCompletableFuture().get(2, TimeUnit.SECONDS);
+        assertThat((byte[]) retrieved.value()).isEqualTo(payload);
+    }
+
+    @Test
+    void putBinaryAsync_should_fail_with_clear_error_for_non_byte_array_value() throws Exception {
+        try {
+            delegate
+                .putBinaryAsync(element("bin-bad", "this is a String, not byte[]", 0))
+                .toCompletionStage()
+                .toCompletableFuture()
+                .get(2, TimeUnit.SECONDS);
+            org.assertj.core.api.Fail.fail("expected IllegalArgumentException");
+        } catch (java.util.concurrent.ExecutionException e) {
+            assertThat(e.getCause())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("bin-bad")
+                .hasMessageContaining("String");
+        }
+    }
+
+    @Test
+    void string_path_should_still_work_unchanged() {
+        delegate.put(element("text-key", "text-value", 0));
+
+        Element retrieved = delegate.get("text-key");
+
+        assertThat(retrieved.value()).isEqualTo("text-value");
     }
 
     private static Element element(Object key, Object value, int ttl) {


### PR DESCRIPTION
## Summary

Overrides the new `Cache.getBinaryAsync` / `Cache.putBinaryAsync` methods (added in provider-api 2.2.0) with binary-safe Vert.x Redis send/receive, so callers can store and retrieve `byte[]` values without UTF-8 transcoding corruption.

- `putBinaryAsync(Element)` sends via `redis.send(Request.cmd(SETEX|SET).arg(key)[.arg(ttl)].arg(byte[]))` (Vert.x Redis `Request.arg(byte[])` is binary-safe).
- `getBinaryAsync(key)` calls `redis.send(Request.cmd(GET).arg(key))` and returns the element with `value()` = `byte[]` via `Response.toBytes()`.
- The existing `String`-typed `getAsync` / `putAsync` are **unchanged** — text-only consumers (e.g. `gravitee-policy-oauth2`) keep working exactly as before.

Constructor change: `RedisDelegate` now takes the `Redis` client (was `RedisAPI`), derives `RedisAPI` internally. Needed because `RedisAPI` doesn't expose `send(Request)`. Internal-only — only `RedisCacheResource` constructs `RedisDelegate`.

## Why

Part of [APIM-13628](https://gravitee.atlassian.net/browse/APIM-13628) — the cache policy is moving to a binary frame format to eliminate JSON+Base64 overhead on large payloads. The policy emits `byte[]`; we need a binary-safe Redis path that doesn't corrupt non-UTF-8 bytes.

## Jira

[APIM-13628](https://gravitee.atlassian.net/browse/APIM-13628)

## Sibling PRs

- gravitee-resource-cache-provider-api — adds the interface methods (must merge first): https://github.com/gravitee-io/gravitee-resource-cache-provider-api/pull/44
- gravitee-policy-cache — uses the new methods: https://github.com/gravitee-io/gravitee-policy-cache/pull/104

## Test plan

- [x] `RedisDelegateIntegrationTest`: 5 new tests against real Redis (Testcontainers):
  - `should_round_trip_binary_value_byte_identical` (1KB byte sweep)
  - `should_preserve_non_utf8_bytes_via_binary_path` (`0xC0/0xC1/0xF5/0xFF`)
  - `getBinaryAsync_should_return_null_when_missing`
  - `putBinaryAsync_should_honor_ttl`
  - `string_path_should_still_work_unchanged` (legacy `String` round-trip)
- [x] All 38 existing tests still pass.
- [ ] End-to-end through gateway + Redis verified locally; see APIM-13628 comments.

## CI status note

This PR currently **fails to compile** because `gravitee-resource-cache-provider-api` 2.2.0 (with the new interface methods) is not yet released. CI green is gated on the sibling PR merging and a new BOM release picking up the API change. **Do not change versions** until that's in place.

## Release ordering

Merge + release sequence: provider-api → BOM update → this repo → gravitee-policy-cache.

[APIM-13628]: https://gravitee.atlassian.net/browse/APIM-13628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APIM-13628]: https://gravitee.atlassian.net/browse/APIM-13628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.0-feat-APIM-13628-binary-values-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache-redis/5.0.0-feat-APIM-13628-binary-values-SNAPSHOT/gravitee-resource-cache-redis-5.0.0-feat-APIM-13628-binary-values-SNAPSHOT.zip)
  <!-- Version placeholder end -->
