### PR TITLE
fix(redis-cache): fail open on Redis errors [APIM-14356]

### DIFF
--- a/src/main/java/io/gravitee/resource/cache/redis/RedisDelegate.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/RedisDelegate.java
@@ -104,7 +104,19 @@ public class RedisDelegate implements Cache {
         return redisAPI
             .get(redisKey)
             .timeout(commandTimeoutMs, TimeUnit.MILLISECONDS)
-            .map(response -> response != null ? toElement(key, response.toString()) : null);
+            .map(response -> response != null ? toElement(key, response.toString()) : null)
+            .otherwise(failOpenMiss("get", key));
+    }
+
+    /**
+     * Fail-open for reads: on any Redis error (unreachable, timeout, command failure) log and
+     * treat it as a cache miss so the caller proceeds to the origin instead of failing the request.
+     */
+    private java.util.function.Function<Throwable, Element> failOpenMiss(String op, Object key) {
+        return error -> {
+            log.warn("[redis-cache-{}] Redis operation failed for key '{}', treating as cache miss: {}", op, key, error.getMessage());
+            return null;
+        };
     }
 
     @Override
@@ -118,7 +130,18 @@ public class RedisDelegate implements Cache {
         } else {
             future = redisAPI.set(List.of(redisKey, value));
         }
-        return future.timeout(commandTimeoutMs, TimeUnit.MILLISECONDS).mapEmpty();
+        return future.timeout(commandTimeoutMs, TimeUnit.MILLISECONDS).<Void>mapEmpty().otherwise(failOpenWrite("put", element.key()));
+    }
+
+    /**
+     * Fail-open for writes/evictions: on any Redis error log and complete normally so the cache
+     * acts as a transparent optimisation — a Redis outage degrades to "no caching", never a request failure.
+     */
+    private java.util.function.Function<Throwable, Void> failOpenWrite(String op, Object key) {
+        return error -> {
+            log.warn("[redis-cache-{}] Redis operation failed for key '{}', skipping cache {}: {}", op, key, op, error.getMessage());
+            return null;
+        };
     }
 
     @Override
@@ -128,7 +151,8 @@ public class RedisDelegate implements Cache {
         return redisClient
             .send(request)
             .timeout(commandTimeoutMs, TimeUnit.MILLISECONDS)
-            .map(response -> response != null ? toElement(key, response.toBytes()) : null);
+            .map(response -> response != null ? toElement(key, response.toBytes()) : null)
+            .otherwise(failOpenMiss("getBinary", key));
     }
 
     @Override
@@ -149,13 +173,21 @@ public class RedisDelegate implements Cache {
         Request request = ttl > 0
             ? Request.cmd(Command.SETEX).arg(redisKey).arg(String.valueOf(ttl)).arg(value)
             : Request.cmd(Command.SET).arg(redisKey).arg(value);
-        return redisClient.send(request).timeout(commandTimeoutMs, TimeUnit.MILLISECONDS).mapEmpty();
+        return redisClient
+            .send(request)
+            .timeout(commandTimeoutMs, TimeUnit.MILLISECONDS)
+            .<Void>mapEmpty()
+            .otherwise(failOpenWrite("putBinary", element.key()));
     }
 
     @Override
     public Future<Void> evictAsync(Object key) {
         String redisKey = buildKey(key);
-        return redisAPI.del(List.of(redisKey)).timeout(commandTimeoutMs, TimeUnit.MILLISECONDS).mapEmpty();
+        return redisAPI
+            .del(List.of(redisKey))
+            .timeout(commandTimeoutMs, TimeUnit.MILLISECONDS)
+            .<Void>mapEmpty()
+            .otherwise(failOpenWrite("evict", key));
     }
 
     /**
@@ -177,7 +209,7 @@ public class RedisDelegate implements Cache {
             log.warn("[redis-cache] clear() skipped: ATTR_API_DEPLOYED_AT missing from context");
             return Future.succeededFuture();
         }
-        return scanAndDelete("0", cacheName + "*:" + deployAt);
+        return scanAndDelete("0", cacheName + "*:" + deployAt).otherwise(failOpenWrite("clear", cacheName));
     }
 
     private Future<Void> scanAndDelete(String cursor, String pattern) {

--- a/src/test/java/io/gravitee/resource/cache/redis/RedisDelegateFailOpenTest.java
+++ b/src/test/java/io/gravitee/resource/cache/redis/RedisDelegateFailOpenTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.cache.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.resource.cache.api.Element;
+import io.vertx.core.Vertx;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisOptions;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Fail-open behaviour: when Redis is unreachable, cache operations must degrade gracefully
+ * (cache miss / no-op) so the request still succeeds, rather than failing it. Regression test
+ * for APIM-14356 (the Vert.x rewrite previously propagated the connection failure → HTTP 500).
+ */
+class RedisDelegateFailOpenTest {
+
+    // Nothing listens here, so every Redis command fails with "connection refused".
+    private static final String UNREACHABLE = "redis://127.0.0.1:63999";
+
+    private static Vertx vertx;
+    private static Redis downClient;
+
+    private RedisDelegate delegate;
+
+    @BeforeAll
+    static void bootstrap() {
+        vertx = Vertx.vertx();
+        downClient = Redis.createClient(vertx, new RedisOptions().setConnectionString(UNREACHABLE));
+    }
+
+    @AfterAll
+    static void shutdown() {
+        downClient.close();
+        vertx.close();
+    }
+
+    private <T> T await(io.vertx.core.Future<T> future) throws Exception {
+        return future.toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void getAsync_returns_cache_miss_when_redis_unreachable() throws Exception {
+        delegate = new RedisDelegate(downClient, "gravitee:", Map.of(), 60, false, 2000L);
+
+        Element result = await(delegate.getAsync("some-key"));
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void putAsync_completes_as_noop_when_redis_unreachable() throws Exception {
+        delegate = new RedisDelegate(downClient, "gravitee:", Map.of(), 60, false, 2000L);
+
+        // Against an unreachable Redis the future can only succeed if the fail-open handler caught
+        // the failure — so succeeded() proves the no-op recovery path ran (not a silent success).
+        io.vertx.core.Future<Void> future = delegate.putAsync(element("k", "v", 0));
+        await(future);
+
+        assertThat(future.succeeded()).isTrue();
+    }
+
+    @Test
+    void getBinaryAsync_returns_cache_miss_when_redis_unreachable() throws Exception {
+        delegate = new RedisDelegate(downClient, "gravitee:", Map.of(), 60, false, 2000L);
+
+        Element result = await(delegate.getBinaryAsync("some-key"));
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void putBinaryAsync_completes_as_noop_when_redis_unreachable() throws Exception {
+        delegate = new RedisDelegate(downClient, "gravitee:", Map.of(), 60, false, 2000L);
+
+        io.vertx.core.Future<Void> future = delegate.putBinaryAsync(element("k", "v".getBytes(), 0));
+        await(future);
+
+        assertThat(future.succeeded()).isTrue();
+    }
+
+    @Test
+    void evictAsync_completes_as_noop_when_redis_unreachable() throws Exception {
+        delegate = new RedisDelegate(downClient, "gravitee:", Map.of(), 60, false, 2000L);
+
+        io.vertx.core.Future<Void> future = delegate.evictAsync("some-key");
+        await(future);
+
+        assertThat(future.succeeded()).isTrue();
+    }
+
+    @Test
+    void clearAsync_completes_as_noop_when_redis_unreachable() throws Exception {
+        // releaseCache=true + a deployAt drives the SCAN/DEL path, which must also fail open.
+        delegate = new RedisDelegate(downClient, "gravitee:", Map.of(ExecutionContext.ATTR_API_DEPLOYED_AT, "123"), 60, true, 2000L);
+
+        io.vertx.core.Future<Void> future = delegate.clearAsync();
+        await(future);
+
+        assertThat(future.succeeded()).isTrue();
+    }
+
+    @Test
+    void putBinaryAsync_still_rejects_non_byte_array_value() {
+        delegate = new RedisDelegate(downClient, "gravitee:", Map.of(), 60, false, 2000L);
+
+        // A type error is a programming bug, not a Redis outage — it must NOT be swallowed by fail-open.
+        io.vertx.core.Future<Void> future = delegate.putBinaryAsync(element("k", "not-bytes", 0));
+
+        assertThat(future.failed()).isTrue();
+        assertThat(future.cause()).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static Element element(Object key, Object value, int ttl) {
+        return new Element() {
+            @Override
+            public Object key() {
+                return key;
+            }
+
+            @Override
+            public Object value() {
+                return value;
+            }
+
+            @Override
+            public int timeToLive() {
+                return ttl;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## APIM-14356 — Redis Cache resource: fail open on Redis outage

Restores graceful degradation in the `cache-redis` resource. After the Lettuce→Vert.x rewrite (APIM-13556), a Redis outage caused **HTTP 500** for any API using a `cache` policy with this resource, whereas the previous Lettuce-based 4.0.4 resource degraded gracefully (cache skipped, request served). This is a fail-closed → fail-open regression.

### Fix
`RedisDelegate` async ops now **fail open** — on any Redis error (unreachable, timeout, command failure) they log a WARN and degrade instead of propagating:

* `getAsync` / `getBinaryAsync` → cache **miss** (`null`)
* `putAsync` / `putBinaryAsync` / `evictAsync` / `clearAsync` → **no-op** (complete normally)

All six async methods now share one fail-open contract (`clearAsync`'s SCAN/DEL path included). The sync `get`/`put`/`evict`/`clear` already degrade via `awaitBlocking`. The cache acts as a transparent optimisation: a Redis outage degrades to "no caching", never a request failure.

The binary-put **type validation still throws** (a programming error, not an outage — intentionally not swallowed).

### Tests
New `RedisDelegateFailOpenTest` (real Vert.x client → unreachable port), red→green per behaviour:

* `getAsync` / `getBinaryAsync` return a cache miss when Redis is unreachable
* `putAsync` / `putBinaryAsync` / `evictAsync` / `clearAsync` complete as no-ops — asserted via `future.succeeded()`, which against an unreachable Redis can only hold if the fail-open handler ran
* guard: `putBinaryAsync` still rejects a non-`byte[]` value

Fail-open suite: 7 green. Full module (incl. real-Redis integration happy path) green.

### Verified live
Built the patched plugin, swapped it into a 4.12.x gateway, called an API with a `cache` policy while Redis was down: **HTTP 200** (was 500), with the cache failure logged as a WARN. Verified for both v2 and v4 APIs and against 4.11.x (parity confirmed).

### Notes
* Deployment never required Redis on either version (lazy connect) — this is purely a **runtime resilience** fix.
* Unrelated to the Redis Cluster rate-limit work (APIM-14146).
* The fail-open WARN logs `error.getMessage()` (concise) rather than full stack traces, to avoid log flooding on the request path during an outage.

Fixes APIM-14356.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.0-wba-APIM-14356-cache-redis-fail-open-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-cache-redis/5.0.0-wba-APIM-14356-cache-redis-fail-open-SNAPSHOT/gravitee-resource-cache-redis-5.0.0-wba-APIM-14356-cache-redis-fail-open-SNAPSHOT.zip)
  <!-- Version placeholder end -->
