### PR TITLE
fix(redis-cache): Added legacy check for ssl

### DIFF
--- a/src/main/java/io/gravitee/resource/cache/redis/configuration/RedisCacheResourceConfiguration.java
+++ b/src/main/java/io/gravitee/resource/cache/redis/configuration/RedisCacheResourceConfiguration.java
@@ -19,12 +19,14 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.plugin.annotation.ConfigurationEvaluator;
 import io.gravitee.plugin.configurations.ssl.SslOptions;
 import io.gravitee.resource.api.ResourceConfiguration;
 import io.gravitee.secrets.api.annotation.Secret;
 import io.gravitee.secrets.api.el.FieldKind;
 import java.util.Map;
+import lombok.AccessLevel;
 import lombok.CustomLog;
 import lombok.Getter;
 import lombok.Setter;
@@ -40,6 +42,8 @@ import lombok.Setter;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RedisCacheResourceConfiguration implements ResourceConfiguration {
 
+    private static final ObjectMapper SSL_MAPPER = new ObjectMapper();
+
     // Redis connection fields (aligned with RedisClientOptions shape)
     private String host = "localhost";
     private int port = 6379;
@@ -48,7 +52,10 @@ public class RedisCacheResourceConfiguration implements ResourceConfiguration {
     private String password;
 
     private boolean useSsl = true;
+
+    @Setter(AccessLevel.NONE)
     private SslOptions ssl;
+
     private RedisSentinelConfiguration sentinel = new RedisSentinelConfiguration();
 
     // Cache-specific fields
@@ -116,6 +123,21 @@ public class RedisCacheResourceConfiguration implements ResourceConfiguration {
     @JsonGetter("sentinelMode")
     public boolean getSentinelMode() {
         return isSentinelEnabled();
+    }
+
+    /**
+     * Backward compatibility: accept legacy boolean {@code ssl} (ignored; use {@code useSsl})
+     * or an {@link SslOptions} object.
+     */
+    @JsonSetter("ssl")
+    public void setSsl(Object ssl) {
+        if (ssl == null) {
+            this.ssl = null;
+        } else if (ssl instanceof Boolean legacyBoolean) {
+            log.warn("Legacy boolean 'ssl={}' detected on Redis cache resource config; ignored. Use 'useSsl' instead.", legacyBoolean);
+        } else {
+            this.ssl = SSL_MAPPER.convertValue(ssl, SslOptions.class);
+        }
     }
 
     /**

--- a/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceTest.java
+++ b/src/test/java/io/gravitee/resource/cache/redis/RedisCacheResourceTest.java
@@ -466,6 +466,26 @@ class RedisCacheResourceTest {
         assertThat(cfg).isNotNull();
     }
 
+    @Test
+    void should_ignore_legacy_boolean_ssl_and_keep_useSsl_on_deserialization() throws Exception {
+        String json = "{\"useSsl\":true,\"ssl\":true}";
+        RedisCacheResourceConfiguration cfg = new ObjectMapper().readValue(json, RedisCacheResourceConfiguration.class);
+
+        assertThat(cfg).isNotNull();
+        assertThat(cfg.isUseSsl()).isTrue();
+        assertThat(cfg.getSsl()).isNull();
+    }
+
+    @Test
+    void should_deserialize_ssl_object_normally() throws Exception {
+        String json = "{\"ssl\":{\"trustAll\":true}}";
+        RedisCacheResourceConfiguration cfg = new ObjectMapper().readValue(json, RedisCacheResourceConfiguration.class);
+
+        assertThat(cfg).isNotNull();
+        assertThat(cfg.getSsl()).isNotNull();
+        assertThat(cfg.getSsl().isTrustAll()).isTrue();
+    }
+
     private static HostAndPort hostAndPort(String host, int port) {
         HostAndPort hp = new HostAndPort();
         hp.setHost(host);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14791

## Description

Add backward-compatible handling for legacy boolean "ssl" on Redis cache resource config.

In 5.0.0, "ssl" became an SslOptions object while some APIs still have "ssl": true next to "useSsl". Deserializing that boolean failed, which discarded the plugin classloader and later caused a LinkageError / gateway crash-loop when another Redis resource loaded.

The config setter now accepts both shapes: boolean ssl is warned and ignored (useSsl remains the source of truth), and object ssl still binds as SslOptions. 

Unit tests cover both cases.

Tested with APIM.

## Additional context

Before : 

https://github.com/user-attachments/assets/73004934-8b2f-49e5-8698-ed4bffcabb53

After  :


https://github.com/user-attachments/assets/0a51bb95-5858-4ca3-8148-cc56735a4e98



